### PR TITLE
Ensure Compatibility with pip ≥25.3 by Adding pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ git clone https://github.com/LFL-Lab/SQuADDS.git
 ```bash
 conda activate <YOUR-ENV>
 cd SQuADDS
-pip install -r requirements.txt
 pip install -e .
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,63 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "SQuADDS"
+version = "0.3.7"
+description = "An open-source database of superconducting quantum device designs with a user-friendly interface."
+readme = "README.md"
+requires-python = ">=3.10"
+license = "MIT"
+
+authors = [
+    {name = "Sadman Ahmed Shanto", email = "shanto@usc.edu"}
+]
+
+dependencies = [
+    "dask==2024.6.2",
+    "datasets==2.19.2",
+    "huggingface_hub==0.21.4",
+    "memory_profiler==0.61.0",
+    "numba==0.60.0",
+    "numpy>=1.16.6",
+    "pandas==1.5.3",
+    "prettytable",
+    "psutil==5.9.8",
+    "pyaedt>=0.6.46",
+    "pyarrow==15.0.1",
+    "pyEPR==1.1.5",
+    "pyEPR_quantum>=0.8.5.7",
+    "python-dotenv",
+    "scipy>=1.10.0",
+    "scqubits>=3.3.0",
+    "seaborn",
+    "setuptools",
+    "tabulate",
+    "tqdm",
+    "cython>=0.29.20",
+    "qutip>=4.3.1",
+    "addict",
+    "datashader>=0.16.0",
+    "joblib>=1.3.2",
+    "Requests==2.32.3",
+    "PyGithub==2.4.0",
+    "GitPython==3.1.43",
+    "streamlit==1.45.0",
+    "plotly"
+]
+
+[project.optional-dependencies]
+optional = [
+    "klayout==0.29.10",
+    "gdspy>=1.6.12"
+]
+all = [
+    "klayout==0.29.10",
+    "gdspy>=1.6.12"
+]
+
+[tool.setuptools]
+packages = ["squadds","tutorials"]
+[project.urls]
+repository = "https://github.com/LFL-Lab/SQuADDS"


### PR DESCRIPTION
Starting with pip version 25.3, support for legacy setup.py develop installations has been deprecated in favor of the modern PEP 517/518 standards. This shift can cause installation issues if a proper build backend is not defined, especially when running pip install -r requirements.txt.

To address this, the following changes have been made:

Added a pyproject.toml file to define the build system in compliance with PEP standards.

Removed the outdated pip install -r requirements.txt instruction from the README, as it is no longer applicable under the new configuration.

These updates ensure compatibility with recent versions of pip and modern Python packaging practices.