### PR TITLE
docs: FAQ entry for datasets<4.7 Json feature error

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,11 +434,12 @@ For inquiries or support, please contact [Sadman Ahmed Shanto](mailto:shanto@usc
 | Firas Abouzahr        | Northwestern                                           | Bug Hunter                           |
 
 ## Developers
-- [shanto268](https://github.com/shanto268) - 438 contributions
+- [shanto268](https://github.com/shanto268) - 439 contributions
 - [elizabethkunz](https://github.com/elizabethkunz) - 17 contributions
 - [LFL-Lab](https://github.com/LFL-Lab) - 9 contributions
 - [NxtGenLegend](https://github.com/NxtGenLegend) - 1 contributions
 - [ethanzhen7](https://github.com/ethanzhen7) - 1 contributions
 - [PCodeShark25](https://github.com/PCodeShark25) - 1 contributions
 ---
+
 

--- a/README.md
+++ b/README.md
@@ -441,5 +441,3 @@ For inquiries or support, please contact [Sadman Ahmed Shanto](mailto:shanto@usc
 - [ethanzhen7](https://github.com/ethanzhen7) - 1 contributions
 - [PCodeShark25](https://github.com/PCodeShark25) - 1 contributions
 ---
-
-

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -134,6 +134,16 @@ Accessing the Database
 
 **A:** If you encounter errors upon instantiating the `SQuADDS_DB` class, there may be a caching issue. Delete the ``SQuADDS`` dataset from the huggingface cache directory on your local machine. The cache directory is typically located at ``~/.cache/huggingface/datasets/``.
 
+**Q:** ``db.select_qubit("TransmonCross")`` **raises** ``TypeError: argument of type 'NoneType' is not iterable`` **and** ``db.supported_components()`` **returns** ``[]`` **. What is going on?**
+
+**A:** This happens on environments where the installed ``datasets`` package is older than ``4.7.0`` (typically ``SQuADDS <= 0.4.3`` installs that pulled ``datasets>=2.19`` via the loose version pin). The ``SQuADDS_DB`` dataset's auto-generated schema on the Hugging Face datasets-server uses the new ``Json()`` feature type (introduced in ``datasets==4.7.0``) to describe columns whose values mix dicts and JSON strings. Older clients crash or silently fall back to a single ``['default']`` config, which then fails the ``count("-") == 2`` filter in ``load_supported_config_names`` and leaves ``supported_components()`` empty. Upgrade in your environment:
+
+.. code-block:: bash
+
+   pip install --upgrade "datasets>=4.7" "huggingface_hub>=0.25"
+
+``SQuADDS >= 0.4.4`` pins ``datasets>=4.8.1`` so new installs are unaffected.
+
 ``.env`` File
 -------------
 


### PR DESCRIPTION
## Summary

Adds a single Q&A to the `Accessing the Database` FAQ in `docs/source/getting_started.rst` covering the recent support issue where users on `SQuADDS <= 0.4.3` envs (which pinned `datasets>=2.19` loosely) hit:

```
Component `qubit` not supported. Available components are: []
TypeError: argument of type 'NoneType' is not iterable
```

when calling `db.select_system("qubit")` / `db.select_qubit("TransmonCross")`.

### Root cause (for context)

`SQuADDS_DB`'s auto-generated Hugging Face `datasets-server` schema now uses the new `Json()` feature type (introduced in `datasets==4.7.0`) to describe columns whose values mix dicts and JSON strings (`cplr_opts`, `lead`, `meander`, etc.). Any `datasets<4.7` client either crashes with `ValueError: Feature type 'Json' not found` or silently falls back to a single `['default']` config, which then fails the `count("-") == 2` filter in `load_supported_config_names` and leaves `supported_components()` empty.

### Fix for affected users (in the FAQ)

```bash
pip install --upgrade "datasets>=4.7" "huggingface_hub>=0.25"
```

`SQuADDS >= 0.4.4` (the next release, cut from PR #55) pins `datasets>=4.8.1`, so new installs will not hit this.

## Test plan

- [x] Docs-only change; no code paths or tests affected.
- [ ] Sphinx docs build (CI) completes without warnings on the modified FAQ section.

Made with [Cursor](https://cursor.com)