### PR TITLE
docs(readme): add ML Models section and list tutorials 10/11

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,4 +477,3 @@ For inquiries or support, please contact [Sadman Ahmed Shanto](mailto:shanto@usc
 - [ethanzhen7](https://github.com/ethanzhen7) - 1 contributions
 - [PCodeShark25](https://github.com/PCodeShark25) - 1 contributions
 ---
-

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The SQuADDS (Superconducting Qubit And Device Design and Simulation) Database Pr
   - [Run using Docker](#run-using-docker)
 - [Tutorials](#tutorials)
 - [MCP Server (AI Agent Integration)](#mcp-server-ai-agent-integration)
+- [ML Models](#ml-models)
 - [Contributing](#contributing)
 - [License](#license)
 - [FAQs](#faqs)
@@ -197,6 +198,8 @@ The following tutorials are available to help you get started with `SQuADDS`:
 - [Tutorial 7: Simulate designs with palace](https://lfl-lab.github.io/SQuADDS/source/tutorials/Tutorial-7_Simulate_designs_with_palace.html)
 - [Tutorial 8: ML Interpolation in SQuADDS](https://lfl-lab.github.io/SQuADDS/source/tutorials/Tutorial-8_ML_interpolation_in_SQuADDS.html)
 - [Tutorial 9: Learning the Inverse Map](https://lfl-lab.github.io/SQuADDS/source/tutorials/Tutorial-9_Learing_the_Inverse_Design_Map.html)
+- [Tutorial 10: HFSS Driven-Modal Capacitance Extraction](https://lfl-lab.github.io/SQuADDS/source/tutorials/Tutorial-10_DrivenModal_Capacitance_Extraction.html)
+- [Tutorial 11: Unified Driven-Modal Hamiltonian Extraction](https://lfl-lab.github.io/SQuADDS/source/tutorials/Tutorial-11_DrivenModal_Combined_Hamiltonian_Extraction.html)
 
 ---
 
@@ -377,6 +380,39 @@ With `mcp.json`:
 </details>
 
 **Full MCP documentation:** [MCP_README.md](MCP_README.md) | **Developer guide:** [MCP_DEVELOPER_GUIDE.md](MCP_DEVELOPER_GUIDE.md)
+
+---
+
+## ML Models
+
+We host ML models trained on SQuADDS on our [Hugging Face org](https://huggingface.co/SQuADDS), served through the [SQuADDS ML Inference API Space](https://huggingface.co/spaces/SQuADDS/squadds-ml-inference-api).
+
+Our first production model is a **qubit-claw (TransmonCross) Hamiltonian-to-geometry inverse** model, developed in collaboration with Taylor Patti, Nicola Pancotti, Enectali Figueroa-Feliciano, Sara Sussman, Olivia Seidel, Firas Abouzahr, Eli Levenson-Falk, and Sadman Ahmed Shanto — with **Olivia Seidel and Firas Abouzahr** as the primary trainers.
+
+<details>
+<summary><strong>transmon_cross_hamiltonian_inverse — usage</strong></summary>
+
+- Model repo: <https://huggingface.co/SQuADDS/transmon-cross-hamiltonian-inverse>
+- Space / live API: <https://squadds-squadds-ml-inference-api.hf.space>
+- Routes: `GET /health`, `GET /models`, `POST /predict`
+
+Recommended agent flow: `GET /models` → pick a model with `status="ready"` → `POST /predict` with that `model_id` and the exact input keys it advertises.
+
+```bash
+curl -X POST \
+  https://squadds-squadds-ml-inference-api.hf.space/predict \
+  -H 'Content-Type: application/json' \
+  -d '{"model_id":"transmon_cross_hamiltonian_inverse","inputs":{"qubit_frequency_GHz":4.85,"anharmonicity_MHz":-205.0}}'
+```
+
+Inputs: `qubit_frequency_GHz`, `anharmonicity_MHz`.
+Outputs (SI units, meters): `design_options.connection_pads.readout.claw_length`, `design_options.connection_pads.readout.ground_spacing`, `design_options.cross_length`. Feed those straight into SQuADDS / Qiskit Metal downstream flows.
+
+Full contract, sample response, and manifest: see the [model repo README](https://huggingface.co/SQuADDS/transmon-cross-hamiltonian-inverse) and the [Space README](https://huggingface.co/spaces/SQuADDS/squadds-ml-inference-api).
+
+</details>
+
+More models are coming — resonator and qubit-cavity coupled-system inverses are next (the deployment tooling already knows about these families, so they drop in once checkpoints land). **If you've trained a well-performing SQuADDS-based model, please PR it in** — open an issue or PR against [SQuADDS/squadds-ml-inference-api](https://huggingface.co/spaces/SQuADDS/squadds-ml-inference-api) and we'll get it on the model page.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ With `mcp.json`:
 
 ## ML Models
 
-We host ML models trained on SQuADDS on our [Hugging Face org](https://huggingface.co/SQuADDS), served through the [SQuADDS ML Inference API Space](https://huggingface.co/spaces/SQuADDS/squadds-ml-inference-api).
+We host ML models trained on SQuADDS on our [Hugging Face org](https://huggingface.co/SQuADDS), served through the [SQuADDS ML Inference API Space](https://huggingface.co/spaces/SQuADDS/squadds-ml-inference-api). Docsite page: [ML Models](https://lfl-lab.github.io/SQuADDS/source/ml_models.html).
 
 Our first production model is a **qubit-claw (TransmonCross) Hamiltonian-to-geometry inverse** model, developed in collaboration with Taylor Patti, Nicola Pancotti, Enectali Figueroa-Feliciano, Sara Sussman, Olivia Seidel, Firas Abouzahr, Eli Levenson-Falk, and Sadman Ahmed Shanto — with **Olivia Seidel and Firas Abouzahr** as the primary trainers.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ SQuADDS is an open-source platform aimed at speeding up the design loop in the c
    Installation <source/getting_started>
    Tutorials <source/tutorials/index>
    MCP Server <source/mcp_server>
+   ML Models <source/ml_models>
    Documentation <source/apidocs/index>
    Contributions <source/resources/contribute>
    Developer Notes <source/developer/index>
@@ -61,6 +62,7 @@ Quick Links
 - `Getting Started Guide <https://lfl-lab.github.io/SQuADDS/source/getting_started.html>`_: Learn how to set up and start using SQuADDS.
 - `Tutorials <https://lfl-lab.github.io/SQuADDS/source/tutorials/index.html>`_: Step-by-step guides for common workflows and use cases.
 - `MCP Server <https://lfl-lab.github.io/SQuADDS/source/mcp_server.html>`_: Connect AI coding assistants to the SQuADDS database.
+- `ML Models <https://lfl-lab.github.io/SQuADDS/source/ml_models.html>`_: Hosted SQuADDS ML inverse-design models on Hugging Face.
 - `Chat with the Codebase <https://deepwiki.com/LFL-Lab/SQuADDS>`_: Chat with the codebase using DeepWiki.
 - `API Reference <https://lfl-lab.github.io/SQuADDS/source/apidocs/index.html>`_: Explore the full API documentation for SQuADDS.
 - `Contribution Portal <https://squadds-portal.vercel.app/>`_: Contribute to SQuADDS in seconds.

--- a/docs/source/ml_models.rst
+++ b/docs/source/ml_models.rst
@@ -1,0 +1,130 @@
+ML Models (Hosted Inference)
+============================
+
+SQuADDS hosts ML models trained on the SQuADDS dataset on our `Hugging Face org <https://huggingface.co/SQuADDS>`_, served through the `SQuADDS ML Inference API Space <https://huggingface.co/spaces/SQuADDS/squadds-ml-inference-api>`_. Use this page as the entry point when you want a stable HTTP surface for inverse-design predictions rather than loading Keras checkpoints yourself.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+
+Live Endpoints
+--------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Resource
+     - URL
+   * - Space repo
+     - `huggingface.co/spaces/SQuADDS/squadds-ml-inference-api <https://huggingface.co/spaces/SQuADDS/squadds-ml-inference-api>`_
+   * - API host
+     - ``https://squadds-squadds-ml-inference-api.hf.space``
+   * - Current model repo
+     - `huggingface.co/SQuADDS/transmon-cross-hamiltonian-inverse <https://huggingface.co/SQuADDS/transmon-cross-hamiltonian-inverse>`_
+
+API routes:
+
+- ``GET /health`` — liveness.
+- ``GET /models`` — list deployed models and their ``status`` / input-output contract.
+- ``POST /predict`` — run inference for a given ``model_id`` with its exact input keys.
+
+
+Recommended Agent Workflow
+--------------------------
+
+1. Call ``GET /models`` and inspect the response.
+2. Pick a model whose ``status`` is ``"ready"``.
+3. Send ``POST /predict`` with that ``model_id`` and the exact input keys it advertises.
+4. Feed the returned geometry parameters straight into SQuADDS / Qiskit Metal / validation flows.
+
+
+Current Live Model
+------------------
+
+``transmon_cross_hamiltonian_inverse`` predicts TransmonCross (qubit-claw) geometry from target Hamiltonian inputs.
+
+- **Expected inputs** (SQuADDS-native units): ``qubit_frequency_GHz``, ``anharmonicity_MHz``.
+- **Returned outputs** (SI units, meters): ``design_options.connection_pads.readout.claw_length``, ``design_options.connection_pads.readout.ground_spacing``, ``design_options.cross_length``.
+
+
+Sample Request
+^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+   curl -X POST \
+     https://squadds-squadds-ml-inference-api.hf.space/predict \
+     -H 'Content-Type: application/json' \
+     -d '{"model_id":"transmon_cross_hamiltonian_inverse","inputs":{"qubit_frequency_GHz":4.85,"anharmonicity_MHz":-205.0}}'
+
+
+Sample Response
+^^^^^^^^^^^^^^^
+
+.. code-block:: json
+
+   {
+     "model_id": "transmon_cross_hamiltonian_inverse",
+     "display_name": "TransmonCross Hamiltonian to Geometry",
+     "predictions": [
+       {
+         "design_options.connection_pads.readout.claw_length": 0.00011072495544794947,
+         "design_options.connection_pads.readout.ground_spacing": 4.571595582092414e-06,
+         "design_options.cross_length": 0.0002005973074119538
+       }
+     ],
+     "metadata": {
+       "input_order": ["qubit_frequency_GHz", "anharmonicity_MHz"],
+       "output_order": [
+         "design_options.connection_pads.readout.claw_length",
+         "design_options.connection_pads.readout.ground_spacing",
+         "design_options.cross_length"
+       ],
+       "input_units": {
+         "qubit_frequency_GHz": "GHz",
+         "anharmonicity_MHz": "MHz"
+       },
+       "output_units": {
+         "design_options.connection_pads.readout.claw_length": "m",
+         "design_options.connection_pads.readout.ground_spacing": "m",
+         "design_options.cross_length": "m"
+       },
+       "num_predictions": 1
+     }
+   }
+
+Full per-model contract (``X_names``, output order, scalers, ``inference_manifest.json``) lives on the `model repo <https://huggingface.co/SQuADDS/transmon-cross-hamiltonian-inverse>`_.
+
+
+Acknowledgments
+---------------
+
+The first live model (``transmon_cross_hamiltonian_inverse``) was developed in collaboration with Taylor Patti, Nicola Pancotti, Enectali Figueroa-Feliciano, Sara Sussman, Olivia Seidel, Firas Abouzahr, Eli Levenson-Falk, and Sadman Ahmed Shanto — with **Olivia Seidel and Firas Abouzahr** as the primary trainers.
+
+
+Current Limitations
+-------------------
+
+- Only ``transmon_cross_hamiltonian_inverse`` is live today. Resonator and coupled-system inverse models are next — the deployment tooling already knows about those families, so they drop in once checkpoints land.
+- Outputs are returned in meters; convert to SQuADDS/Qiskit-Metal micrometer strings (``"…um"``) before writing back into ``design_options``.
+- No authentication today; the Space is rate-limited by Hugging Face. Do not rely on it for production-scale batch inference.
+
+
+Contributing a Model
+--------------------
+
+If you have a well-performing SQuADDS-based model, please PR it in. Open an issue or PR against `SQuADDS/squadds-ml-inference-api <https://huggingface.co/spaces/SQuADDS/squadds-ml-inference-api>`_ with:
+
+- a model checkpoint following the existing ``model/`` / ``scalers/`` / ``inference_manifest.json`` layout,
+- the exact input/output columns and units, and
+- a short description that can go on the Space's model card.
+
+
+Further Reading
+---------------
+
+- Space README: `huggingface.co/spaces/SQuADDS/squadds-ml-inference-api <https://huggingface.co/spaces/SQuADDS/squadds-ml-inference-api>`_
+- Model repo README + ``inference_manifest.json``: `huggingface.co/SQuADDS/transmon-cross-hamiltonian-inverse <https://huggingface.co/SQuADDS/transmon-cross-hamiltonian-inverse>`_
+- SQuADDS dataset: `huggingface.co/datasets/SQuADDS/SQuADDS_DB <https://huggingface.co/datasets/SQuADDS/SQuADDS_DB>`_

--- a/wish_list.md
+++ b/wish_list.md
@@ -52,6 +52,7 @@ Refer to [contribution guidelines](CONTRIBUTING.md) for more information on how 
 ## Machine Learning (ML):
 
 - Develop an architecture/framework for deploying ML models on SQuADDS (via HuggingFace endpoints/spaces, in code, etc.)
+- Add MCP tooling for hosted SQuADDS ML models (wrap the [SQuADDS ML Inference API](https://huggingface.co/spaces/SQuADDS/squadds-ml-inference-api) as MCP tools so agents can discover available models via `GET /models` and run inverse-design predictions via `POST /predict` without hand-writing HTTP calls)
 - Provide APIs (modules/methods) for incorporating ML interpolation features into SQuADDS
 - Utilize HuggingFace Tasks for ML applications
 - Identify relevant design space variables for any system given a set of $\hat{H}$ parameters using encoders


### PR DESCRIPTION
## Summary

- README was missing the two new driven-modal tutorial entries shipped in #55; add Tutorial 10 and Tutorial 11 to the tutorial list so README ↔ docsite ↔ shipped notebooks all line up.
- Add a new `ML Models` section (with a TOC entry) advertising the SQuADDS Hugging Face org and the [SQuADDS ML Inference API Space](https://huggingface.co/spaces/SQuADDS/squadds-ml-inference-api). Highlights the first live model — `transmon_cross_hamiltonian_inverse` (qubit-claw Hamiltonian → geometry) — with a collapsible usage block (routes, agent flow, `curl` example, I/O fields) and links to the model repo / Space READMEs. Acknowledges the collaborators listed on the model repo's README (primary trainers: Olivia Seidel and Firas Abouzahr) and invites PRs of other well-performing SQuADDS-based models.
- Wishlist: add "MCP tooling for hosted SQuADDS ML models" so agents can wrap `GET /models` + `POST /predict` as MCP tools once the inference API grows more model families.

## Test plan

- [ ] GitHub renders the new `ML Models` section (collapsible details open/close correctly, TOC anchor `#ml-models` resolves).
- [ ] Tutorial 10/11 links resolve on the docsite once the new docs build publishes.

Made with [Cursor](https://cursor.com)