### PR TITLE
Add generalized interdigital capacitor component and dataset support

### DIFF
--- a/docs/source/developer/index.rst
+++ b/docs/source/developer/index.rst
@@ -129,5 +129,5 @@ Contributors
 | **Sara Sussman, PhD** (Fermilab) - Bug Hunter 🐛
 | **Priyangshu Chatterjee** (IIT Kharagpur) -  Documentation contributor 📄
 | **Abhishek Chakraborty** (Rigetti Computing) - Code contributor 💻
-| **Saikat Das** (University of Southern California) - Reviewer ✅
+| **Saikat Das** (University of Southern California) - Data contributor 📀 and Reviewer ✅
 | **Firas Abouzahr** (Northwestern) - Bug Hunter 🐛

--- a/scripts/convert_generalized_ncap_dataset.py
+++ b/scripts/convert_generalized_ncap_dataset.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+"""Build the GeneralizedCapNInterdigital Hugging Face dataset artifact."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from squadds.database.generalized_ncap_dataset import convert_dataset
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source_root", type=Path)
+    parser.add_argument("output_path", type=Path)
+    args = parser.parse_args()
+    count = convert_dataset(args.source_root, args.output_path)
+    print(f"Wrote {count} rows to {args.output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/squadds/components/__init__.py
+++ b/squadds/components/__init__.py
@@ -1,3 +1,9 @@
+from .component_registry import build_component_from_design, create_coupler, get_coupler_spec
 from .generalized_ncap_interdigital import GeneralizedCapNInterdigital
 
-__all__ = ["GeneralizedCapNInterdigital"]
+__all__ = [
+    "GeneralizedCapNInterdigital",
+    "build_component_from_design",
+    "create_coupler",
+    "get_coupler_spec",
+]

--- a/squadds/components/__init__.py
+++ b/squadds/components/__init__.py
@@ -1,0 +1,3 @@
+from .generalized_ncap_interdigital import GeneralizedCapNInterdigital
+
+__all__ = ["GeneralizedCapNInterdigital"]

--- a/squadds/components/cavity_claw.py
+++ b/squadds/components/cavity_claw.py
@@ -4,6 +4,7 @@ from qiskit_metal import Dict
 from qiskit_metal.qlibrary.core import QComponent
 
 from squadds.components.claw_coupler import TransmonClaw
+from squadds.components.component_registry import create_coupler, get_coupler_spec
 
 
 class CavityClaw(QComponent):
@@ -71,7 +72,7 @@ class CavityClaw(QComponent):
         qubit_opts["pos_y"] = 0
         try:
             qubit_opts["pos_x"] = "-1500um" if p.cavity_claw_options["cpw_opts"].total_length > 2.500 else "-1000um"
-        except:
+        except KeyError:
             qubit_opts["pos_x"] = "-1500um" if p.cavity_claw_options["cpw_options"].total_length > 2.500 else "-1000um"
         self.qubit = TransmonClaw(self.design, f"{self.name}_xmon", options=qubit_opts)
 
@@ -95,21 +96,17 @@ class CavityClaw(QComponent):
         temp_opts = Dict()
         try:
             self.copier(temp_opts, p.cavity_claw_options["coupler_options"])
-        except:
+        except KeyError:
             self.copier(temp_opts, p.cavity_claw_options["cplr_opts"])
 
-        if p.cavity_claw_options["coupler_type"].upper() == "CLT":
-            from qiskit_metal.qlibrary.couplers.coupled_line_tee import CoupledLineTee
-
-            self.coupler = CoupledLineTee(self.design, f"{self.name}_CLT_coupler", options=temp_opts)
-        elif (
-            p.cavity_claw_options["coupler_type"].lower() == "capn"
-            or p.cavity_claw_options["coupler_type"].lower() == "ncap"
-            or p.cavity_claw_options["coupler_type"].lower() == "capninterdigitaltee"
-        ):
-            from qiskit_metal.qlibrary.couplers.cap_n_interdigital_tee import CapNInterdigitalTee
-
-            self.coupler = CapNInterdigitalTee(self.design, f"{self.name}_capn_coupler", options=temp_opts)
+        coupler_type = p.cavity_claw_options["coupler_type"]
+        spec = get_coupler_spec(coupler_type)
+        self.coupler = create_coupler(
+            coupler_type,
+            self.design,
+            f"{self.name}_{spec.instance_suffix}",
+            temp_opts,
+        )
 
     def make_cpws(self):
         """
@@ -123,7 +120,7 @@ class CavityClaw(QComponent):
         p = self.p
         try:
             p.cpw_opts = p.cavity_claw_options["cpw_opts"]
-        except:
+        except KeyError:
             p.cpw_opts = p.cavity_claw_options["cpw_options"]
 
         left_opts = Dict()
@@ -168,7 +165,9 @@ class CavityClaw(QComponent):
         left_opts["pin_inputs"]["start_pin"].update({"pin": list(self.qubit.options["connection_pads"].keys())[0]})
 
         left_opts["pin_inputs"]["end_pin"].update({"component": self.coupler.name})
-        left_opts["pin_inputs"]["end_pin"].update({"pin": "second_end"})
+        left_opts["pin_inputs"]["end_pin"].update(
+            {"pin": get_coupler_spec(p.cavity_claw_options["coupler_type"]).route_pin}
+        )
 
         self.LeftMeander = RouteMeander(self.design, f"{self.name}_left_cpw", options=left_opts)
 
@@ -201,10 +200,10 @@ class CavityClaw(QComponent):
         Returns:
             None
         """
-        start_dict = self.coupler.get_pin("prime_start")
-        end_dict = self.coupler.get_pin("prime_end")
-        self.add_pin("prime_start", start_dict["points"], start_dict["width"])
-        self.add_pin("prime_end", end_dict["points"], end_dict["width"])
+        spec = get_coupler_spec(self.p.cavity_claw_options["coupler_type"])
+        for pin_name in spec.exposed_pins:
+            pin = self.coupler.get_pin(pin_name)
+            self.add_pin(pin_name, pin["points"], pin["width"], gap=pin.get("gap"))
 
     def make_wirebond_pads(self):
         from qiskit_metal.qlibrary.terminations.launchpad_wb import LaunchpadWirebond

--- a/squadds/components/component_registry.py
+++ b/squadds/components/component_registry.py
@@ -1,0 +1,84 @@
+"""Resolve dataset component names to their Qiskit Metal implementations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from qiskit_metal.qlibrary.core import QComponent
+
+
+@dataclass(frozen=True)
+class CouplerSpec:
+    """Construction and pin roles for a supported coupler."""
+
+    component_class: type[QComponent]
+    route_pin: str
+    exposed_pins: tuple[str, ...]
+    instance_suffix: str
+
+
+def _normalized_component_name(component_name: str) -> str:
+    return component_name.replace("_", "").replace("-", "").lower()
+
+
+def get_coupler_spec(component_name: str) -> CouplerSpec:
+    """Return the implementation and pin roles for a coupler name."""
+    normalized = _normalized_component_name(component_name)
+    if normalized == "generalizedcapninterdigital":
+        from squadds.components.generalized_ncap_interdigital import GeneralizedCapNInterdigital
+
+        return CouplerSpec(
+            component_class=GeneralizedCapNInterdigital,
+            route_pin="south_end",
+            exposed_pins=("north_end",),
+            instance_suffix="generalized_ncap_coupler",
+        )
+
+    if normalized in {"capn", "ncap", "capninterdigitaltee"}:
+        from qiskit_metal.qlibrary.couplers.cap_n_interdigital_tee import CapNInterdigitalTee
+
+        return CouplerSpec(
+            component_class=CapNInterdigitalTee,
+            route_pin="second_end",
+            exposed_pins=("prime_start", "prime_end"),
+            instance_suffix="capn_coupler",
+        )
+
+    if normalized in {"clt", "coupledlinetee"}:
+        from qiskit_metal.qlibrary.couplers.coupled_line_tee import CoupledLineTee
+
+        return CouplerSpec(
+            component_class=CoupledLineTee,
+            route_pin="second_end",
+            exposed_pins=("prime_start", "prime_end"),
+            instance_suffix="CLT_coupler",
+        )
+
+    raise ValueError(f"Unsupported coupler component: {component_name}")
+
+
+def create_coupler(component_name: str, design, name: str, options: dict[str, Any] | None = None) -> QComponent:
+    """Instantiate a named coupler using its registered implementation."""
+    spec = get_coupler_spec(component_name)
+    return spec.component_class(design, name, options=options or {})
+
+
+def build_component_from_design(design, row: dict[str, Any], name: str = "cplr") -> QComponent:
+    """Build the exact component declared by a SQuADDS dataset row.
+
+    Both nested Hugging Face records and second-level flattened API records are
+    accepted. GeneralizedCapNInterdigital is intentionally resolved only from
+    ``squadds.components``.
+    """
+    design_record = row.get("design", row)
+    component_name = (
+        design_record.get("component_class")
+        or design_record.get("component_name")
+        or design_record.get("coupler_type")
+    )
+    if not component_name:
+        raise ValueError("Dataset row does not declare a component class or coupler type.")
+
+    options = design_record.get("design_options", row.get("design_options", {}))
+    return create_coupler(component_name, design, name, options)

--- a/squadds/components/component_registry.py
+++ b/squadds/components/component_registry.py
@@ -73,9 +73,7 @@ def build_component_from_design(design, row: dict[str, Any], name: str = "cplr")
     """
     design_record = row.get("design", row)
     component_name = (
-        design_record.get("component_class")
-        or design_record.get("component_name")
-        or design_record.get("coupler_type")
+        design_record.get("component_class") or design_record.get("component_name") or design_record.get("coupler_type")
     )
     if not component_name:
         raise ValueError("Dataset row does not declare a component class or coupler type.")

--- a/squadds/components/coupled_systems.py
+++ b/squadds/components/coupled_systems.py
@@ -5,6 +5,8 @@ from qiskit_metal import Dict
 from qiskit_metal.qlibrary.core import QComponent
 from qiskit_metal.qlibrary.qubits.transmon_cross import TransmonCross
 
+from squadds.components.component_registry import create_coupler, get_coupler_spec
+
 
 class QubitCavity(QComponent):
     """
@@ -59,7 +61,7 @@ class QubitCavity(QComponent):
         warnings.warn(
             "QubitCavity is a convenience wrapper for quick visualization only. "
             "For production designs, build components individually (TransmonCross, "
-            "CoupledLineTee, RouteMeander) to control trace widths, fillets, and "
+            "the selected coupler, RouteMeander) to control trace widths, fillets, and "
             "lead straights. See SQuADDS Tutorial 5 or the MCP layout-guide resource. "
             "If you see CPW kinks, increase 'lead.start_straight' / 'lead.end_straight' "
             "on the RouteMeander (try 75um / 50um).",
@@ -112,18 +114,14 @@ class QubitCavity(QComponent):
         )
         self.copier(temp_opts, coupler_options)
 
-        if p.cavity_claw_options["coupler_type"].upper() == "CLT":
-            from qiskit_metal.qlibrary.couplers.coupled_line_tee import CoupledLineTee
-
-            self.coupler = CoupledLineTee(self.design, f"{self.name}_CLT_coupler", options=temp_opts)
-        elif (
-            p.cavity_claw_options["coupler_type"].lower() == "capn"
-            or p.cavity_claw_options["coupler_type"].lower() == "ncap"
-            or p.cavity_claw_options["coupler_type"].lower() == "capninterdigitaltee"
-        ):
-            from qiskit_metal.qlibrary.couplers.cap_n_interdigital_tee import CapNInterdigitalTee
-
-            self.coupler = CapNInterdigitalTee(self.design, f"{self.name}_capn_coupler", options=temp_opts)
+        coupler_type = p.cavity_claw_options["coupler_type"]
+        spec = get_coupler_spec(coupler_type)
+        self.coupler = create_coupler(
+            coupler_type,
+            self.design,
+            f"{self.name}_{spec.instance_suffix}",
+            temp_opts,
+        )
 
     def make_cpws(self):
         """
@@ -199,7 +197,9 @@ class QubitCavity(QComponent):
         left_opts["pin_inputs"]["start_pin"].update({"pin": list(self.qubit.options["connection_pads"].keys())[0]})
 
         left_opts["pin_inputs"]["end_pin"].update({"component": self.coupler.name})
-        left_opts["pin_inputs"]["end_pin"].update({"pin": "second_end"})
+        left_opts["pin_inputs"]["end_pin"].update(
+            {"pin": get_coupler_spec(p.cavity_claw_options["coupler_type"]).route_pin}
+        )
 
         self.LeftMeander = RouteMeander(self.design, f"{self.name}_left_cpw", options=left_opts)
 
@@ -251,10 +251,10 @@ class QubitCavity(QComponent):
         Returns:
             None
         """
-        start_dict = self.coupler.get_pin("prime_start")
-        end_dict = self.coupler.get_pin("prime_end")
-        self.add_pin("prime_start", start_dict["points"], start_dict["width"])
-        self.add_pin("prime_end", end_dict["points"], end_dict["width"])
+        spec = get_coupler_spec(self.p.cavity_claw_options["coupler_type"])
+        for pin_name in spec.exposed_pins:
+            pin = self.coupler.get_pin(pin_name)
+            self.add_pin(pin_name, pin["points"], pin["width"], gap=pin.get("gap"))
 
     def make_wirebond_pads(self):
         from qiskit_metal.qlibrary.terminations.launchpad_wb import LaunchpadWirebond

--- a/squadds/components/generalized_ncap_interdigital.py
+++ b/squadds/components/generalized_ncap_interdigital.py
@@ -1,0 +1,1317 @@
+import numpy as np
+from qiskit_metal import Dict, draw
+from qiskit_metal.qlibrary.core import QComponent
+from shapely import set_precision
+from shapely.affinity import rotate, translate
+from shapely.errors import GEOSException
+from shapely.geometry import LineString, Polygon
+
+
+class GeneralizedCapNInterdigital(QComponent):
+    @staticmethod
+    def _clean_geometry(geom, precision=1e-6):
+        """Repair potentially invalid polygons before/after precision snapping."""
+        if geom is None:
+            return geom
+
+        # First pass: resolve obvious self-intersections.
+        geom = geom.buffer(0)
+        try:
+            geom = set_precision(geom, precision)
+        except GEOSException:
+            # Fallback path for borderline-topology cases that fail on snap.
+            geom = geom.buffer(0)
+            geom = set_precision(geom, precision)
+        return geom.buffer(0)
+
+    default_options = Dict(
+        north_cpw_length="20um",
+        north_cpw_width="10um",
+        north_cpw_gap="6um",
+        north_cpw_radius="0um",
+        north_cpw_etch_radius="0um",
+        north_cpw_xpos_offset="0um",
+        north_cpw_maintain_gap=True,
+        #
+        south_cpw_length="20um",
+        south_cpw_width="10um",
+        south_cpw_gap="6um",
+        south_cpw_radius="0um",
+        south_cpw_etch_radius="0um",
+        south_cpw_xpos_offset="0um",
+        south_cpw_maintain_gap=True,
+        #
+        north_spine_width="10um",
+        north_west_spine_radius="0um",
+        north_east_spine_radius="0um",
+        north_west_spine_etch_radius="0um",
+        north_east_spine_etch_radius="0um",
+        #
+        south_spine_width="10um",
+        south_west_spine_radius="0um",
+        south_east_spine_radius="0um",
+        south_west_spine_etch_radius="0um",
+        south_east_spine_etch_radius="0um",
+        #
+        north_gap_ground="6um",
+        south_gap_ground="6um",
+        east_gap_ground="6um",
+        west_gap_ground="6um",
+        #
+        finger_length="20um",
+        finger_width="10um",
+        finger_gap_north_south="6um",
+        finger_gap_east_west="6um",
+        finger_radius="0um",
+        finger_etch_radius="0um",
+        finger_edge_gap_radius="0um",
+        finger_count="5",
+    )
+
+    def make(self):
+        # self._install_hfss_scalar_safe_polyline_patch()
+        p = self.p
+
+        # north body is rotated 180 degrees, so for building it, the x-directions need to be flipped
+        p.north_cpw_xpos_offset = -p.north_cpw_xpos_offset
+        self._initialize_calculated_variables()
+
+        num_fingers = int(p.finger_count)
+        is_finger_count_even = num_fingers % 2 == 0
+
+        if is_finger_count_even:
+            finger_count_south = finger_count_north = num_fingers // 2
+        else:
+            finger_count_south = num_fingers // 2 + 1
+            finger_count_north = num_fingers // 2
+
+        assert p.finger_length >= 0.0, "finger_length must be greater than or equal to 0"
+
+        if p.finger_length > 0.0:
+            assert p.finger_count > 0, "finger_count must be greater than 0 if finger_length is greater than 0"
+
+            assert p.finger_radius <= p.finger_width / 2, (
+                f"finger_radius must be <= half the finger_width (= {p.finger_width / 2 * 1000} um)"
+            )
+            assert (p.finger_length - (p.finger_radius + p.finger_etch_radius)) >= -1e-6, (
+                "Must have finger_length >= finger_radius + finger_etch_radius in order to render"
+            )
+
+        assert (p.north_cpw_length - p.north_cpw_radius) >= 0.0, (
+            "north_cpw_length must be larger than or equal to north_cpw_radius in order to render"
+        )
+        assert (p.south_cpw_length - p.south_cpw_radius) >= 0.0, (
+            "south_cpw_length must be larger than or equal to south_cpw_radius in order to render"
+        )
+
+        y_translation_offset = -self.cap_height - p.north_cpw_length
+
+        cap_south_body = self._make_cap_body(is_body_south=True, finger_count=finger_count_south)
+        cap_south_body = translate(cap_south_body, 0, y_translation_offset)
+        cap_south_body = self._clean_geometry(cap_south_body)
+
+        cap_north_body = self._make_cap_body(
+            is_body_south=False, finger_count=finger_count_north, gap_first=False if is_finger_count_even else True
+        )
+        cap_north_body = rotate(cap_north_body, 180, origin=(0, 0))
+        cap_north_body = translate(cap_north_body, 0, self.cap_height + y_translation_offset)
+        cap_north_body = self._clean_geometry(cap_north_body)
+
+        # switch it back for etch
+        p.north_cpw_xpos_offset = -p.north_cpw_xpos_offset
+        self._initialize_calculated_variables()
+
+        cap_etch = self._make_cap_etch()
+        cap_etch = translate(
+            cap_etch,
+            self.etch_width / 2 - p.west_gap_ground - self.cap_width / 2,
+            -p.south_gap_ground + y_translation_offset,
+        )
+        cap_etch = self._clean_geometry(cap_etch)
+
+        c_items = [cap_north_body, cap_south_body, cap_etch]
+        c_items = draw.rotate(c_items, p.orientation, origin=(0, 0))
+        c_items = draw.translate(c_items, p.pos_x, p.pos_y)
+        [cap_north_body, cap_south_body, cap_etch] = c_items
+
+        self.add_qgeometry("poly", {"cap_etch": cap_etch}, layer=p.layer, subtract=True)
+        self.add_qgeometry("poly", {"cap_north_body": cap_north_body}, layer=p.layer)
+        self.add_qgeometry("poly", {"cap_south_body": cap_south_body}, layer=p.layer)
+
+        south_cpw_edge_coords = np.array(
+            [
+                (self.south_cpw_left_edge_x, -p.south_cpw_length + y_translation_offset),
+                (self.south_cpw_right_edge_x, -p.south_cpw_length + y_translation_offset),
+            ]
+        )
+        north_cpw_edge_coords = np.array(
+            [
+                (self.north_cpw_left_edge_x, self.cap_height + p.north_cpw_length + y_translation_offset),
+                (self.north_cpw_right_edge_x, self.cap_height + p.north_cpw_length + y_translation_offset),
+            ]
+        )
+        cpw_edge_lines = [
+            LineString(south_cpw_edge_coords),
+            LineString(north_cpw_edge_coords),
+        ]
+        cpw_edge_lines = draw.rotate(cpw_edge_lines, p.orientation, origin=(0, 0))
+        cpw_edge_lines = draw.translate(cpw_edge_lines, p.pos_x, p.pos_y)
+        south_cpw_edge_coords = np.array(cpw_edge_lines[0].coords)
+        north_cpw_edge_coords = np.array(cpw_edge_lines[1].coords)
+
+        self.add_pin(
+            "south_end",
+            points=south_cpw_edge_coords[::-1],
+            width=p.south_cpw_width,
+            gap=p.south_cpw_gap,
+        )
+        self.add_pin(
+            "north_end",
+            points=north_cpw_edge_coords,
+            width=p.north_cpw_width,
+            gap=p.north_cpw_gap,
+        )
+
+    def _initialize_calculated_variables(self):
+        p = self.p
+
+        self.cap_width = p.finger_count * p.finger_width + (p.finger_count - 1) * p.finger_gap_east_west
+        self.cap_height = p.south_spine_width + p.finger_length + p.finger_gap_north_south + p.north_spine_width
+
+        self.south_cpw_left_edge_x = p.south_cpw_xpos_offset - p.south_cpw_width / 2
+        self.south_cpw_right_edge_x = p.south_cpw_xpos_offset + p.south_cpw_width / 2
+        self.north_cpw_left_edge_x = p.north_cpw_xpos_offset - p.north_cpw_width / 2
+        self.north_cpw_right_edge_x = p.north_cpw_xpos_offset + p.north_cpw_width / 2
+
+        self.etch_width = self.cap_width + p.west_gap_ground + p.east_gap_ground
+        self.etch_height = self.cap_height + p.north_gap_ground + p.south_gap_ground
+        self.etch_left_edge_x = -self.cap_width / 2 - p.west_gap_ground
+        self.etch_right_edge_x = self.cap_width / 2 + p.east_gap_ground
+
+        self.finger_gap_width = p.finger_width + 2 * p.finger_gap_east_west
+
+    def _get_rounded_corner_coords(
+        self, r, quadrant, corner_coords, clockwise=False, start_angle=None, end_angle=None, num_points=16
+    ):
+        if r < 1e-6:
+            return [corner_coords]
+
+        x = corner_coords[0]
+        y = corner_coords[1]
+
+        if quadrant == "ne":
+            angle_start = 0
+            angle_end = np.pi / 2
+            if clockwise:
+                angle_start, angle_end = angle_end, angle_start
+            x = x - r
+            y = y - r
+
+        elif quadrant == "nw":
+            angle_start = np.pi / 2
+            angle_end = np.pi
+            if clockwise:
+                angle_start, angle_end = angle_end, angle_start
+            x = x + r
+            y = y - r
+
+        elif quadrant == "sw":
+            angle_start = -np.pi
+            angle_end = -np.pi / 2
+            if clockwise:
+                angle_start, angle_end = angle_end, angle_start
+            x = x + r
+            y = y + r
+
+        elif quadrant == "se":
+            angle_start = -np.pi / 2
+            angle_end = 0
+            if clockwise:
+                angle_start, angle_end = angle_end, angle_start
+            x = x - r
+            y = y + r
+
+        if start_angle is None:
+            start_angle = angle_start
+        if end_angle is None:
+            end_angle = angle_end
+
+        theta = np.linspace(start_angle, end_angle, num_points)
+        x_vals = r * np.cos(theta) + x
+        y_vals = r * np.sin(theta) + y
+        return [(float(xv), float(yv)) for xv, yv in zip(x_vals, y_vals)]
+
+    def _get_partial_corner_info(self, cpw_center, spine_center, cpw_radius, spine_radius, y_int_val=0.0):
+        x1, y1 = cpw_center
+        x2, y2 = spine_center
+        R1 = cpw_radius
+        R2 = spine_radius
+
+        dx, dy = x2 - x1, y2 - y1
+        d = np.sqrt(dx**2 + dy**2)
+
+        c = (R1 + R2) / d
+        s = np.sqrt(d**2 - (R1 + R2) ** 2) / d
+
+        nx1 = c * (dx / d) - s * (dy / d)
+        ny1 = c * (dy / d) + s * (dx / d)
+
+        nx2 = c * (dx / d) + s * (dy / d)
+        ny2 = c * (dy / d) - s * (dx / d)
+
+        pt1x_circ1, pt1y_circ1 = x1 + R1 * nx1, y1 + R1 * ny1
+        pt1x_circ2, pt1y_circ2 = x2 - R2 * nx1, y2 - R2 * ny1
+
+        pt2x_circ1, pt2y_circ1 = x1 + R1 * nx2, y1 + R1 * ny2
+        pt2x_circ2, pt2y_circ2 = x2 - R2 * nx2, y2 - R2 * ny2
+
+        if abs(pt1y_circ1 - y_int_val) < 1e-6:
+            pt_circ1 = np.array([pt2x_circ1, pt2y_circ1])
+            pt_circ2 = np.array([pt2x_circ2, pt2y_circ2])
+        else:
+            pt_circ1 = np.array([pt1x_circ1, pt1y_circ1])
+            pt_circ2 = np.array([pt1x_circ2, pt1y_circ2])
+
+        numerator = (pt_circ1[0] * pt_circ2[1] - pt_circ2[0] * pt_circ1[1]) + y_int_val * (pt_circ2[0] - pt_circ1[0])
+        denominator = pt_circ2[1] - pt_circ1[1]
+        int_point = np.array([numerator / denominator, y_int_val])
+
+        xc1, yc1 = cpw_center
+        xt1, yt1 = pt_circ1
+        dx = xt1 - xc1
+        dy = yt1 - yc1
+        angle1 = np.arctan2(dy, dx)
+
+        xc2, yc2 = spine_center
+        xt2, yt2 = pt_circ2
+        dx = xt2 - xc2
+        dy = yt2 - yc2
+        angle2 = np.arctan2(dy, dx)
+
+        info_dict = {
+            "int_point": int_point.tolist(),
+            "pt_circ1": pt_circ1.tolist(),
+            "pt_circ2": pt_circ2.tolist(),
+            "cpw_angle": angle1,
+            "spine_angle": angle2,
+        }
+        return info_dict
+
+    def _get_finger_coords(self, start_coord, exclude_left_ledge=False, exclude_right_ledge=False):
+        p = self.p
+        length = p.finger_length
+        width = p.finger_width
+        rf = p.finger_radius
+        re = p.finger_etch_radius
+        gap_width = self.finger_gap_width
+        start_x = start_coord[0]
+        start_y = start_coord[1]
+
+        coords = []
+        x = start_x
+        y = start_y
+
+        if exclude_left_ledge:
+            y = y + length
+            coords.extend(self._get_rounded_corner_coords(rf, "nw", (x, y), clockwise=True))
+        else:
+            x = x + gap_width / 2
+            coords.extend(self._get_rounded_corner_coords(re, "se", (x, y)))
+
+            y = y + length
+            coords.extend(self._get_rounded_corner_coords(rf, "nw", (x, y), clockwise=True))
+
+        x = x + width
+        coords.extend(self._get_rounded_corner_coords(rf, "ne", (x, y), clockwise=True))
+
+        if not exclude_right_ledge:
+            y = y - length
+            coords.extend(self._get_rounded_corner_coords(re, "sw", (x, y)))
+
+        return coords, x, y
+
+    def _spine_ledge_geometry(self, side: str, y: float) -> dict:
+        """Circle/fillet centers for the spine ledge at the outer finger gap."""
+        p = self.p
+        if side == "left":
+            circ_center_x = -self.cap_width / 2 - p.finger_gap_east_west + p.finger_etch_radius
+            fillet_center_x = -self.cap_width / 2 + p.finger_edge_gap_radius
+        else:
+            circ_center_x = self.cap_width / 2 + p.finger_gap_east_west - p.finger_etch_radius
+            fillet_center_x = self.cap_width / 2 - p.finger_edge_gap_radius
+        circ_center_y = y + p.finger_etch_radius
+        radicand = (p.finger_etch_radius + p.finger_edge_gap_radius) ** 2 - (fillet_center_x - circ_center_x) ** 2
+        fillet_center_y = None
+        fillet_upper_y = None
+        circ_lower_y = circ_center_y - p.finger_etch_radius
+        if radicand >= 0:
+            fillet_center_y = circ_center_y - np.sqrt(radicand)
+            fillet_upper_y = fillet_center_y + p.finger_edge_gap_radius
+        return {
+            "circ_center_x": circ_center_x,
+            "circ_center_y": circ_center_y,
+            "fillet_center_x": fillet_center_x,
+            "fillet_center_y": fillet_center_y,
+            "fillet_upper_y": fillet_upper_y,
+            "circ_lower_y": circ_lower_y,
+            "radicand": radicand,
+        }
+
+    def _spine_ledge_use_simplified(self, side: str, y: float) -> bool:
+        """Use simplified spine-ledge corners when fillet and etch circles overlap.
+
+        Simplified path when the fillet top is at or above the etch-circle bottom
+        (within 1e-6 mm). Otherwise use tangent fillet + etch-arc construction.
+        """
+        geom = self._spine_ledge_geometry(side, y)
+        if geom["radicand"] < 0:
+            return True
+        return (geom["circ_lower_y"] - geom["fillet_upper_y"]) <= 1e-6
+
+    def _append_spine_ledge_left_simplified(self, cap_body_coords: list, y: float) -> None:
+        cap_body_coords.extend(
+            self._get_rounded_corner_coords(
+                self.p.finger_edge_gap_radius,
+                "nw",
+                (-self.cap_width / 2, y),
+                start_angle=np.pi,
+                end_angle=np.pi / 2,
+                clockwise=True,
+            )
+        )
+
+    def _append_spine_ledge_right_simplified(self, cap_body_coords: list, y: float) -> None:
+        cap_body_coords.extend(
+            self._get_rounded_corner_coords(
+                self.p.finger_edge_gap_radius,
+                "ne",
+                (self.cap_width / 2, y),
+                start_angle=np.pi / 2,
+                end_angle=0,
+                clockwise=True,
+            )
+        )
+
+    def _append_spine_ledge_left_tangent(self, cap_body_coords: list, y: float) -> None:
+        p = self.p
+        geom = self._spine_ledge_geometry("left", y)
+        circ_center_x = geom["circ_center_x"]
+        circ_center_y = geom["circ_center_y"]
+        fillet_center_x = geom["fillet_center_x"]
+        fillet_center_y = geom["fillet_center_y"]
+        fillet_angle_end = np.arctan2(circ_center_y - fillet_center_y, circ_center_x - fillet_center_x)
+        theta_start = np.arctan2(fillet_center_y - circ_center_y, fillet_center_x - circ_center_x)
+        cap_body_coords.extend(
+            self._get_rounded_corner_coords(
+                p.finger_edge_gap_radius,
+                "nw",
+                (-self.cap_width / 2, fillet_center_y + p.finger_edge_gap_radius),
+                start_angle=np.pi,
+                end_angle=fillet_angle_end,
+            )
+        )
+        cap_body_coords.extend(
+            self._get_rounded_corner_coords(
+                p.finger_etch_radius,
+                "sw",
+                (circ_center_x - p.finger_etch_radius, y),
+                start_angle=theta_start,
+                end_angle=-np.pi / 2,
+            )
+        )
+
+    def _append_spine_ledge_right_tangent(self, cap_body_coords: list, y: float) -> None:
+        p = self.p
+        geom = self._spine_ledge_geometry("right", y)
+        circ_center_x = geom["circ_center_x"]
+        circ_center_y = geom["circ_center_y"]
+        fillet_center_x = geom["fillet_center_x"]
+        fillet_center_y = geom["fillet_center_y"]
+        fillet_angle_start = np.arctan2(circ_center_y - fillet_center_y, circ_center_x - fillet_center_x)
+        theta_end = np.arctan2(fillet_center_y - circ_center_y, fillet_center_x - circ_center_x)
+        cap_body_coords.extend(
+            self._get_rounded_corner_coords(
+                p.finger_etch_radius,
+                "se",
+                (circ_center_x + p.finger_etch_radius, y),
+                start_angle=-np.pi / 2,
+                end_angle=theta_end,
+            )
+        )
+        cap_body_coords.extend(
+            self._get_rounded_corner_coords(
+                p.finger_edge_gap_radius,
+                "ne",
+                (self.cap_width / 2, fillet_center_y + p.finger_edge_gap_radius),
+                start_angle=fillet_angle_start,
+                end_angle=0,
+            )
+        )
+
+    def _make_cap_body(self, is_body_south, finger_count, gap_first=False):
+        p = self.p
+        if is_body_south:
+            spine_width = p.south_spine_width
+            west_spine_radius = p.south_west_spine_radius
+            east_spine_radius = p.south_east_spine_radius
+            cpw_width = p.south_cpw_width
+            cpw_length = p.south_cpw_length
+            cpw_radius = p.south_cpw_radius
+            cpw_xpos = p.south_cpw_xpos_offset
+            cpw_left_edge_x = self.south_cpw_left_edge_x
+            cpw_right_edge_x = self.south_cpw_right_edge_x
+            dir_text = "south_"
+        else:
+            spine_width = p.north_spine_width
+            west_spine_radius = (
+                p.north_east_spine_radius
+            )  # Direction flipped since north body will be rotated 180 degrees
+            east_spine_radius = p.north_west_spine_radius
+            cpw_width = p.north_cpw_width
+            cpw_length = p.north_cpw_length
+            cpw_radius = p.north_cpw_radius
+            cpw_xpos = p.north_cpw_xpos_offset
+            cpw_left_edge_x = self.north_cpw_left_edge_x
+            cpw_right_edge_x = self.north_cpw_right_edge_x
+            dir_text = "north_"
+
+        assert cpw_length >= cpw_radius, (
+            f"{dir_text}cpw_length must be larger than or equal to {dir_text}cpw_radius in order to render"
+        )
+
+        cap_body_coords = []
+
+        # (0,0) is south spine bottom edge horizontally center
+
+        # LEFT: CPW AND SPINE
+        if cpw_length > 0.0:
+            x = cpw_xpos
+            y = -cpw_length
+
+            # cpw left corner
+            x = x - cpw_width / 2
+            cap_body_coords.append((x, y))
+
+            # cpw spine left connection curve
+            left_edge_x = -self.cap_width / 2
+            y = 0
+
+            wr_partial_valid = (left_edge_x < cpw_left_edge_x) and (
+                (cpw_left_edge_x - cpw_radius) < (left_edge_x + west_spine_radius)
+            )
+            wl_partial_valid = (left_edge_x > cpw_left_edge_x) and (
+                (cpw_left_edge_x + cpw_radius) > (left_edge_x - west_spine_radius)
+            )
+            w_equality_valid = np.abs(left_edge_x - cpw_left_edge_x) < 1e-6
+
+            if not any([wr_partial_valid, wl_partial_valid, w_equality_valid]):
+                # full pi/2 rotations for both curves
+                if left_edge_x < cpw_left_edge_x:  # cpw fully connected to spine
+                    cap_body_coords.extend(self._get_rounded_corner_coords(cpw_radius, "ne", (x, y)))
+                    x = left_edge_x
+                    cap_body_coords.extend(
+                        self._get_rounded_corner_coords(west_spine_radius, "sw", (x, y), clockwise=True)
+                    )
+                else:  # cpw sticking out to the left of the cap body
+                    cap_body_coords.extend(self._get_rounded_corner_coords(cpw_radius, "nw", (x, y), clockwise=True))
+                    x = left_edge_x
+                    cap_body_coords.extend(self._get_rounded_corner_coords(west_spine_radius, "se", (x, y)))
+
+            else:
+                if w_equality_valid:  # straight connection from cpw to spine
+                    cap_body_coords.append((x, y))
+
+                elif wr_partial_valid:  # ne cpw curve -> tilted line -> sw spine curve
+                    spine_circ_center = np.array([left_edge_x + west_spine_radius, west_spine_radius])
+                    cpw_circ_center = np.array([cpw_left_edge_x - cpw_radius, -cpw_radius])
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center, spine_circ_center, cpw_radius, west_spine_radius
+                    )
+
+                    cpw_end_angle = partial_info["cpw_angle"]
+                    assert cpw_end_angle >= 0.0, "DEBUG"
+                    cap_body_coords.extend(
+                        self._get_rounded_corner_coords(
+                            cpw_radius, "ne", (x, y), start_angle=0, end_angle=cpw_end_angle
+                        )
+                    )
+
+                    cap_body_coords.append(partial_info["int_point"])
+
+                    x = left_edge_x
+                    spine_start_angle = partial_info["spine_angle"]
+                    assert spine_start_angle <= 0.0, "DEBUG"
+                    cap_body_coords.extend(
+                        self._get_rounded_corner_coords(
+                            west_spine_radius,
+                            "sw",
+                            (x, y),
+                            clockwise=True,
+                            start_angle=spine_start_angle,
+                            end_angle=-np.pi,
+                        )
+                    )
+
+                elif wl_partial_valid:  # nw cpw curve -> tilted line -> se spine curve
+                    assert left_edge_x < cpw_right_edge_x, (
+                        f"{dir_text}cpw must be connected to capacitor (exceeds {left_edge_x} mm). Reduce offset magnitude"
+                    )
+
+                    spine_circ_center = np.array([left_edge_x - west_spine_radius, west_spine_radius])
+                    cpw_circ_center = np.array([cpw_left_edge_x + cpw_radius, -cpw_radius])
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center, spine_circ_center, cpw_radius, west_spine_radius
+                    )
+
+                    cpw_end_angle = partial_info["cpw_angle"]
+                    assert cpw_end_angle >= 0.0, "DEBUG"
+                    cap_body_coords.extend(
+                        self._get_rounded_corner_coords(
+                            cpw_radius, "nw", (x, y), start_angle=np.pi, end_angle=cpw_end_angle
+                        )
+                    )
+
+                    cap_body_coords.append(partial_info["int_point"])
+
+                    x = -self.cap_width / 2
+                    spine_start_angle = partial_info["spine_angle"]
+                    assert spine_start_angle <= 0.0, "DEBUG"
+                    cap_body_coords.extend(
+                        self._get_rounded_corner_coords(
+                            west_spine_radius, "se", (x, y), clockwise=True, start_angle=spine_start_angle, end_angle=0
+                        )
+                    )
+
+                else:
+                    raise RuntimeError("Should not reach this point. Code logic issue")
+
+        else:
+            # no cpw, just spine
+            x = -self.cap_width / 2
+            y = 0
+            cap_body_coords.extend(self._get_rounded_corner_coords(west_spine_radius, "sw", (x, y), clockwise=True))
+
+        # FINGERS
+        y = y + spine_width
+
+        if p.finger_length > 0.0:
+            if gap_first:
+                if self._spine_ledge_use_simplified("left", y):
+                    self._append_spine_ledge_left_simplified(cap_body_coords, y)
+                else:
+                    self._append_spine_ledge_left_tangent(cap_body_coords, y)
+                x = x + p.finger_width + p.finger_gap_east_west - self.finger_gap_width / 2
+
+            for i in range(finger_count):
+                coords, x, y = self._get_finger_coords(
+                    [x, y],
+                    exclude_left_ledge=True if i == 0 and not gap_first else False,
+                    exclude_right_ledge=True
+                    if i == finger_count - 1 and not gap_first and p.finger_count % 2 == 1
+                    else False,
+                )
+                if i != finger_count - 1:
+                    x = x + self.finger_gap_width / 2
+                cap_body_coords.extend(coords)
+
+            if p.finger_count % 2 == 0 or gap_first:
+                if self._spine_ledge_use_simplified("right", y):
+                    self._append_spine_ledge_right_simplified(cap_body_coords, y)
+                else:
+                    self._append_spine_ledge_right_tangent(cap_body_coords, y)
+        else:
+            cap_body_coords.extend(
+                self._get_rounded_corner_coords(
+                    p.finger_edge_gap_radius,
+                    "nw",
+                    (x, y),
+                    clockwise=True,
+                )
+            )
+            x = x + self.cap_width
+            cap_body_coords.extend(
+                self._get_rounded_corner_coords(
+                    p.finger_edge_gap_radius,
+                    "ne",
+                    (x, y),
+                    clockwise=True,
+                )
+            )
+
+        # RIGHT: CPW AND SPINE
+        right_cpw_spine_coords = []
+        if cpw_length > 0.0:
+            x = cpw_xpos
+            y = -cpw_length
+
+            # cpw left corner
+            x = x + cpw_width / 2
+            right_cpw_spine_coords.append((x, y))
+
+            # cpw spine left connection curve
+            right_edge_x = self.cap_width / 2
+            y = 0
+
+            er_partial_valid = (right_edge_x < cpw_right_edge_x) and (
+                (cpw_right_edge_x - cpw_radius) < (right_edge_x + east_spine_radius)
+            )
+            el_partial_valid = (right_edge_x > cpw_right_edge_x) and (
+                (cpw_right_edge_x + cpw_radius) > (right_edge_x - east_spine_radius)
+            )
+            e_equality_valid = np.abs(right_edge_x - cpw_right_edge_x) < 1e-6
+
+            if not any([er_partial_valid, el_partial_valid, e_equality_valid]):
+                # full pi/2 rotations for both curves
+                if right_edge_x > cpw_right_edge_x:  # cpw fully connected to spine
+                    right_cpw_spine_coords.extend(
+                        self._get_rounded_corner_coords(cpw_radius, "nw", (x, y), clockwise=True)
+                    )
+                    x = right_edge_x
+                    right_cpw_spine_coords.extend(self._get_rounded_corner_coords(east_spine_radius, "se", (x, y)))
+                else:  # cpw sticking out to the left of the cap body
+                    right_cpw_spine_coords.extend(self._get_rounded_corner_coords(cpw_radius, "ne", (x, y)))
+                    x = right_edge_x
+                    right_cpw_spine_coords.extend(
+                        self._get_rounded_corner_coords(east_spine_radius, "sw", (x, y), clockwise=True)
+                    )
+
+            else:
+                if e_equality_valid:  # straight connection from cpw to spine
+                    right_cpw_spine_coords.append((x, y))
+
+                elif el_partial_valid:  # nw cpw curve -> tilted line -> se spine curve
+                    spine_circ_center = np.array([right_edge_x - east_spine_radius, east_spine_radius])
+                    cpw_circ_center = np.array([cpw_right_edge_x + cpw_radius, -cpw_radius])
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center, spine_circ_center, cpw_radius, east_spine_radius
+                    )
+
+                    cpw_end_angle = partial_info["cpw_angle"]
+                    assert cpw_end_angle >= 0.0, "DEBUG"
+                    right_cpw_spine_coords.extend(
+                        self._get_rounded_corner_coords(
+                            cpw_radius, "nw", (x, y), start_angle=np.pi, end_angle=cpw_end_angle, clockwise=True
+                        )
+                    )
+
+                    right_cpw_spine_coords.append(partial_info["int_point"])
+
+                    x = right_edge_x
+                    spine_start_angle = partial_info["spine_angle"]
+                    assert spine_start_angle <= 0.0, "DEBUG"
+                    right_cpw_spine_coords.extend(
+                        self._get_rounded_corner_coords(
+                            east_spine_radius, "se", (x, y), start_angle=spine_start_angle, end_angle=0
+                        )
+                    )
+
+                elif er_partial_valid:  # ne cpw curve -> tilted line -> sw spine curve
+                    assert right_edge_x > cpw_left_edge_x, (
+                        f"{dir_text}cpw must be connected to capacitor (exceeds {right_edge_x} mm). Reduce offset magnitude"
+                    )
+
+                    spine_circ_center = np.array([right_edge_x + east_spine_radius, east_spine_radius])
+                    cpw_circ_center = np.array([cpw_right_edge_x - cpw_radius, -cpw_radius])
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center, spine_circ_center, cpw_radius, east_spine_radius
+                    )
+
+                    cpw_end_angle = partial_info["cpw_angle"]
+                    assert cpw_end_angle >= 0.0, "DEBUG"
+                    right_cpw_spine_coords.extend(
+                        self._get_rounded_corner_coords(
+                            cpw_radius, "ne", (x, y), start_angle=0, end_angle=cpw_end_angle
+                        )
+                    )
+
+                    right_cpw_spine_coords.append(partial_info["int_point"])
+
+                    x = right_edge_x
+                    spine_start_angle = partial_info["spine_angle"]
+                    assert spine_start_angle <= 0.0, "DEBUG"
+                    right_cpw_spine_coords.extend(
+                        self._get_rounded_corner_coords(
+                            east_spine_radius,
+                            "sw",
+                            (x, y),
+                            clockwise=True,
+                            start_angle=spine_start_angle,
+                            end_angle=-np.pi,
+                        )
+                    )
+
+                else:
+                    raise RuntimeError("Should not reach this point. Code logic issue")
+
+        else:
+            # no cpw, just spine
+            x = self.cap_width / 2
+            y = 0
+            right_cpw_spine_coords.extend(self._get_rounded_corner_coords(cpw_radius, "nw", (x, y)))
+
+        cap_body_coords.extend(right_cpw_spine_coords[::-1])
+
+        cap_body = Polygon(cap_body_coords)
+        return cap_body
+
+    def _make_cap_etch(self):
+        p = self.p
+
+        cap_etch_coords = []
+
+        south_cpw_etch_left_edge_x = self.south_cpw_left_edge_x - p.south_cpw_gap
+        south_cpw_etch_right_edge_x = self.south_cpw_right_edge_x + p.south_cpw_gap
+        north_cpw_etch_left_edge_x = self.north_cpw_left_edge_x - p.north_cpw_gap
+        north_cpw_etch_right_edge_x = self.north_cpw_right_edge_x + p.north_cpw_gap
+
+        south_cpw_etch_length = p.south_cpw_length - p.south_gap_ground
+        north_cpw_etch_length = p.north_cpw_length - p.north_gap_ground
+
+        # SOUTH WEST CORNER
+        if p.south_cpw_length > p.south_gap_ground:
+            x = south_cpw_etch_left_edge_x
+            y = -south_cpw_etch_length
+            cap_etch_coords.append((x, y))
+
+            y = 0
+
+            swr_partial_valid = (self.etch_left_edge_x < south_cpw_etch_left_edge_x) and (
+                (south_cpw_etch_left_edge_x - p.south_cpw_etch_radius)
+                < (self.etch_left_edge_x + p.south_west_spine_etch_radius)
+            )
+            swl_partial_valid = (self.etch_left_edge_x > south_cpw_etch_left_edge_x) and (
+                (south_cpw_etch_left_edge_x + p.south_cpw_etch_radius)
+                > (self.etch_left_edge_x - p.south_west_spine_etch_radius)
+            )
+            sw_equality_valid = np.abs(self.etch_left_edge_x - south_cpw_etch_left_edge_x) < 1e-6
+
+            if not any([swr_partial_valid, swl_partial_valid, sw_equality_valid]):
+                # fill pi/2 rotations for both curves
+                if self.etch_left_edge_x < south_cpw_etch_left_edge_x:  # cpw fully connected to spine
+                    cap_etch_coords.extend(self._get_rounded_corner_coords(p.south_cpw_etch_radius, "ne", (x, y)))
+                    x = self.etch_left_edge_x
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.south_west_spine_etch_radius, "sw", (x, y), clockwise=True)
+                    )
+                else:  # cpw sticking out to the left of the cap body
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.south_cpw_etch_radius, "nw", (x, y), clockwise=True)
+                    )
+                    x = self.etch_left_edge_x
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.south_west_spine_etch_radius, "se", (x, y))
+                    )
+
+            else:
+                if sw_equality_valid:  # straight connection from cpw to spine
+                    cap_etch_coords.append((x, y))
+
+                elif swr_partial_valid:  # ne cpw curve -> tilted line -> sw spine curve
+                    spine_circ_center = np.array(
+                        [self.etch_left_edge_x + p.south_west_spine_etch_radius, p.south_west_spine_etch_radius]
+                    )
+                    cpw_circ_center = np.array(
+                        [south_cpw_etch_left_edge_x - p.south_cpw_etch_radius, -p.south_cpw_etch_radius]
+                    )
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center, spine_circ_center, p.south_cpw_etch_radius, p.south_west_spine_etch_radius
+                    )
+
+                    cpw_end_angle = partial_info["cpw_angle"]
+                    assert cpw_end_angle >= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.south_cpw_etch_radius, "ne", (x, y), start_angle=0, end_angle=cpw_end_angle
+                        )
+                    )
+
+                    cap_etch_coords.append(partial_info["int_point"])
+
+                    x = self.etch_left_edge_x
+                    spine_start_angle = partial_info["spine_angle"]
+                    assert spine_start_angle <= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.south_west_spine_etch_radius,
+                            "sw",
+                            (x, y),
+                            clockwise=True,
+                            start_angle=spine_start_angle,
+                            end_angle=-np.pi,
+                        )
+                    )
+
+                elif swl_partial_valid:  # nw cpw curve -> tilted line -> se spine curve
+                    assert self.etch_left_edge_x < south_cpw_etch_right_edge_x, (
+                        f"south_cpw must be connected to capacitor (exceeds {self.etch_left_edge_x} mm). Reduce offset magnitude"
+                    )
+
+                    spine_circ_center = np.array(
+                        [self.etch_left_edge_x - p.south_west_spine_etch_radius, p.south_west_spine_etch_radius]
+                    )
+                    cpw_circ_center = np.array(
+                        [south_cpw_etch_left_edge_x + p.south_cpw_etch_radius, -p.south_cpw_etch_radius]
+                    )
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center, spine_circ_center, p.south_cpw_etch_radius, p.south_west_spine_etch_radius
+                    )
+
+                    cpw_end_angle = partial_info["cpw_angle"]
+                    assert cpw_end_angle >= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.south_cpw_etch_radius, "nw", (x, y), start_angle=np.pi, end_angle=cpw_end_angle
+                        )
+                    )
+
+                    cap_etch_coords.append(partial_info["int_point"])
+
+                    x = -self.cap_width / 2
+                    spine_start_angle = partial_info["spine_angle"]
+                    assert spine_start_angle <= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.south_west_spine_etch_radius,
+                            "se",
+                            (x, y),
+                            clockwise=True,
+                            start_angle=spine_start_angle,
+                            end_angle=0,
+                        )
+                    )
+
+                else:
+                    raise RuntimeError("Should not reach this point. Code logic issue")
+
+        elif p.south_cpw_length > 0.0 and (p.south_cpw_length < p.south_gap_ground):
+            south_cpw_etch_left_edge_x = self.south_cpw_left_edge_x - p.south_cpw_gap
+
+            if south_cpw_etch_left_edge_x < self.etch_width / 2:
+                raise NotImplementedError
+
+        elif p.south_cpw_length < 1e-6:
+            raise NotImplementedError
+
+        # NORTH WEST CORNER
+        if p.south_cpw_length > p.south_gap_ground:
+            x = self.etch_left_edge_x
+            y = self.etch_height
+
+            nwr_partial_valid = (self.etch_left_edge_x < north_cpw_etch_left_edge_x) and (
+                (north_cpw_etch_left_edge_x - p.north_cpw_etch_radius)
+                < (self.etch_left_edge_x + p.north_west_spine_etch_radius)
+            )
+            nwl_partial_valid = (self.etch_left_edge_x > north_cpw_etch_left_edge_x) and (
+                (north_cpw_etch_left_edge_x + p.north_cpw_etch_radius)
+                > (self.etch_left_edge_x - p.north_west_spine_etch_radius)
+            )
+            nw_equality_valid = np.abs(self.etch_left_edge_x - north_cpw_etch_left_edge_x) < 1e-6
+
+            if not any([nwr_partial_valid, nwl_partial_valid, nw_equality_valid]):
+                # fill pi/2 rotations for both curves
+                if self.etch_right_edge_x > south_cpw_etch_right_edge_x:  # cpw fully connected to spine
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.north_west_spine_etch_radius, "nw", (x, y), clockwise=True)
+                    )
+                    x = north_cpw_etch_left_edge_x
+                    cap_etch_coords.extend(self._get_rounded_corner_coords(p.north_cpw_etch_radius, "se", (x, y)))
+                else:  # cpw sticking out to the left of the cap body
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.north_west_spine_etch_radius, "ne", (x, y))
+                    )
+                    x = north_cpw_etch_left_edge_x
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.north_cpw_etch_radius, "sw", (x, y), clockwise=True)
+                    )
+
+            else:
+                if nw_equality_valid:  # straight connection from cpw to spine
+                    cap_etch_coords.append((x, y))
+
+                elif nwr_partial_valid:  # nw spine curve -> tilted line -> se cpw curve
+                    raise NotImplementedError
+                    spine_circ_center = np.array(
+                        [
+                            self.etch_left_edge_x + p.north_west_spine_etch_radius,
+                            self.etch_height - p.north_west_spine_etch_radius,
+                        ]
+                    )
+                    cpw_circ_center = np.array(
+                        [
+                            north_cpw_etch_left_edge_x - p.north_cpw_etch_radius,
+                            self.etch_height + p.north_cpw_etch_radius,
+                        ]
+                    )
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center,
+                        spine_circ_center,
+                        p.north_cpw_etch_radius,
+                        p.north_west_spine_etch_radius,
+                        y_int_val=self.etch_height,
+                    )
+
+                    spine_end_angle = partial_info["spine_angle"]
+                    assert spine_end_angle >= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_west_spine_etch_radius,
+                            "nw",
+                            (x, y),
+                            clockwise=True,
+                            start_angle=np.pi,
+                            end_angle=spine_end_angle,
+                        )
+                    )
+
+                    cap_etch_coords.append(partial_info["int_point"])
+
+                    x = north_cpw_etch_left_edge_x
+                    cpw_start_angle = partial_info["cpw_angle"]
+                    assert cpw_start_angle <= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_cpw_etch_radius, "se", (x, y), start_angle=cpw_start_angle, end_angle=0
+                        )
+                    )
+
+                elif nwl_partial_valid:  # ne spine curve -> tilted line -> sw cpw curve
+                    raise NotImplementedError
+                    assert self.etch_left_edge_x < south_cpw_etch_right_edge_x, (
+                        f"south_cpw must be connected to capacitor (exceeds {self.etch_left_edge_x} mm). Reduce offset magnitude"
+                    )
+
+                    y_int_val = self.etch_height - p.north_gap_ground
+
+                    spine_circ_center = np.array(
+                        [self.etch_left_edge_x - p.north_west_spine_etch_radius, y_int_val - p.north_west_spine_radius]
+                    )
+                    cpw_circ_center = np.array(
+                        [north_cpw_etch_left_edge_x + p.north_cpw_etch_radius, y_int_val + p.north_cpw_radius]
+                    )
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center,
+                        spine_circ_center,
+                        p.north_cpw_etch_radius,
+                        p.north_west_spine_etch_radius,
+                        y_int_val=y_int_val,
+                    )
+
+                    y = y_int_val
+                    spine_end_angle = partial_info["spine_angle"]
+                    assert spine_end_angle >= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_west_spine_etch_radius, "ne", (x, y), start_angle=0, end_angle=spine_end_angle
+                        )
+                    )
+
+                    cap_etch_coords.append(partial_info["int_point"])
+
+                    x = north_cpw_etch_left_edge_x
+                    cpw_start_angle = partial_info["cpw_angle"]
+                    assert cpw_start_angle <= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_cpw_etch_radius,
+                            "sw",
+                            (x, y),
+                            start_angle=cpw_start_angle,
+                            end_angle=-np.pi,
+                            clockwise=True,
+                        )
+                    )
+
+                else:
+                    raise RuntimeError("Should not reach this point. Code logic issue")
+
+            x = north_cpw_etch_left_edge_x
+            y = self.etch_height + north_cpw_etch_length
+            cap_etch_coords.append((x, y))
+
+        elif p.south_cpw_length > 0.0 and (p.south_cpw_length < p.south_gap_ground):
+            south_cpw_etch_left_edge_x = self.south_cpw_left_edge_x - p.south_cpw_gap
+
+            if south_cpw_etch_left_edge_x < self.etch_width / 2:
+                raise NotImplementedError
+
+        elif p.south_cpw_length < 1e-6:
+            raise NotImplementedError
+
+        # NORTH EAST CORNER
+        if p.north_cpw_length > p.north_gap_ground:
+            x = north_cpw_etch_right_edge_x
+            y = self.etch_height + north_cpw_etch_length
+            cap_etch_coords.append((x, y))
+
+            y = self.etch_height
+            ner_partial_valid = (self.etch_right_edge_x < north_cpw_etch_right_edge_x) and (
+                (north_cpw_etch_right_edge_x - p.north_cpw_etch_radius)
+                > (self.etch_left_edge_x + p.north_east_spine_etch_radius)
+            )
+            nel_partial_valid = (self.etch_right_edge_x > north_cpw_etch_right_edge_x) and (
+                (north_cpw_etch_right_edge_x + p.north_cpw_etch_radius)
+                < (self.etch_left_edge_x - p.north_east_spine_etch_radius)
+            )
+            ne_equality_valid = np.abs(self.etch_right_edge_x - north_cpw_etch_right_edge_x) < 1e-6
+
+            if not any([ner_partial_valid, nel_partial_valid, ne_equality_valid]):
+                # fill pi/2 rotations for both curves
+                if self.etch_right_edge_x > north_cpw_etch_right_edge_x:  # cpw fully connected to spine
+                    cap_etch_coords.extend(self._get_rounded_corner_coords(p.north_cpw_etch_radius, "sw", (x, y)))
+                    x = self.etch_right_edge_x
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.north_east_spine_etch_radius, "ne", (x, y), clockwise=True)
+                    )
+                else:  # cpw sticking out to the left of the cap body
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.north_cpw_etch_radius, "se", (x, y), clockwise=True)
+                    )
+                    x = self.etch_right_edge_x
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.north_east_spine_etch_radius, "nw", (x, y))
+                    )
+
+            else:
+                if ne_equality_valid:  # straight connection from cpw to spine
+                    cap_etch_coords.append((x, y))
+
+                elif nel_partial_valid:  # sw cpw curve -> tilted line -> ne spine curve
+                    raise NotImplementedError
+                    spine_circ_center = np.array(
+                        [
+                            self.etch_right_edge_x - p.north_east_spine_etch_radius,
+                            self.etch_height - p.north_east_spine_etch_radius,
+                        ]
+                    )
+                    cpw_circ_center = np.array(
+                        [
+                            north_cpw_etch_right_edge_x + p.north_cpw_etch_radius,
+                            self.etch_height + p.north_cpw_etch_radius,
+                        ]
+                    )
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center, spine_circ_center, p.north_cpw_etch_radius, p.north_east_spine_etch_radius
+                    )
+
+                    x = north_cpw_etch_right_edge_x
+                    cpw_end_angle = partial_info["cpw_angle"]
+                    assert cpw_end_angle <= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_cpw_etch_radius, "se", (x, y), start_angle=cpw_start_angle, end_angle=0
+                        )
+                    )
+
+                    cap_etch_coords.append(partial_info["int_point"])
+
+                    spine_end_angle = partial_info["spine_angle"]
+                    assert spine_end_angle >= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_east_spine_etch_radius,
+                            "nw",
+                            (x, y),
+                            clockwise=True,
+                            start_angle=np.pi,
+                            end_angle=spine_end_angle,
+                        )
+                    )
+
+                elif ner_partial_valid:  # ne spine curve -> tilted line -> sw cpw curve
+                    raise NotImplementedError
+                    assert self.etch_right_edge_x < south_cpw_etch_right_edge_x, (
+                        f"south_cpw must be connected to capacitor (exceeds {self.etch_left_edge_x} mm). Reduce offset magnitude"
+                    )
+
+                    spine_circ_center = np.array(
+                        [self.etch_right_edge_x - p.north_east_spine_etch_radius, p.north_east_spine_etch_radius]
+                    )
+                    cpw_circ_center = np.array(
+                        [north_cpw_etch_right_edge_x + p.north_cpw_etch_radius, -p.north_cpw_etch_radius]
+                    )
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center, spine_circ_center, p.north_cpw_etch_radius, p.north_east_spine_etch_radius
+                    )
+
+                    spine_end_angle = partial_info["spine_angle"]
+                    assert spine_end_angle >= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_east_spine_etch_radius,
+                            "ne",
+                            (x, y),
+                            clockwise=True,
+                            start_angle=0,
+                            end_angle=spine_end_angle,
+                        )
+                    )
+
+                    cap_etch_coords.append(partial_info["int_point"])
+
+                    cpw_start_angle = partial_info["cpw_angle"]
+                    assert cpw_start_angle <= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_cpw_etch_radius, "sw", (x, y), start_angle=cpw_start_angle, end_angle=-np.pi
+                        )
+                    )
+
+                else:
+                    raise RuntimeError("Should not reach this point. Code logic issue")
+
+        elif p.north_cpw_length > 0.0 and (p.north_cpw_length < p.north_gap_ground):
+            north_cpw_etch_left_edge_x = self.north_cpw_left_edge_x - p.north_cpw_gap
+
+            if north_cpw_etch_left_edge_x < self.etch_width / 2:
+                raise NotImplementedError
+
+        elif p.north_cpw_length < 1e-6:
+            raise NotImplementedError
+
+        # SOUTH EAST CORNER
+        if p.north_cpw_length > p.north_gap_ground:
+            x = self.etch_right_edge_x
+            y = 0
+
+            ser_partial_valid = (self.etch_right_edge_x < south_cpw_etch_right_edge_x) and (
+                (south_cpw_etch_right_edge_x - p.south_cpw_etch_radius)
+                < (self.etch_right_edge_x + p.south_east_spine_etch_radius)
+            )
+            sel_partial_valid = (self.etch_right_edge_x > south_cpw_etch_right_edge_x) and (
+                (south_cpw_etch_right_edge_x + p.south_cpw_etch_radius)
+                > (self.etch_right_edge_x - p.south_east_spine_etch_radius)
+            )
+            se_equality_valid = np.abs(self.etch_right_edge_x - south_cpw_etch_right_edge_x) < 1e-6
+
+            if not any([ser_partial_valid, sel_partial_valid, se_equality_valid]):
+                # fill pi/2 rotations for both curves
+                if self.etch_left_edge_x < north_cpw_etch_left_edge_x:  # cpw fully connected to spine
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.south_east_spine_etch_radius, "se", (x, y), clockwise=True)
+                    )
+                    x = south_cpw_etch_right_edge_x
+                    cap_etch_coords.extend(self._get_rounded_corner_coords(p.south_cpw_etch_radius, "nw", (x, y)))
+                else:  # cpw sticking out to the left of the cap body
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.south_east_spine_etch_radius, "sw", (x, y))
+                    )
+                    x = south_cpw_etch_right_edge_x
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(p.south_cpw_etch_radius, "ne", (x, y), clockwise=True)
+                    )
+
+            else:
+                if se_equality_valid:  # straight connection from cpw to spine
+                    cap_etch_coords.append((x, y))
+
+                elif ser_partial_valid:  # nw spine curve -> tilted line -> se cpw curve
+                    raise NotImplementedError
+                    spine_circ_center = np.array(
+                        [
+                            self.etch_left_edge_x + p.north_west_spine_etch_radius,
+                            self.etch_height - p.north_west_spine_etch_radius,
+                        ]
+                    )
+                    cpw_circ_center = np.array(
+                        [
+                            north_cpw_etch_left_edge_x - p.north_cpw_etch_radius,
+                            self.etch_height + p.north_cpw_etch_radius,
+                        ]
+                    )
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center,
+                        spine_circ_center,
+                        p.north_cpw_etch_radius,
+                        p.north_west_spine_etch_radius,
+                        y_int_val=self.etch_height,
+                    )
+
+                    spine_end_angle = partial_info["spine_angle"]
+                    assert spine_end_angle >= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_west_spine_etch_radius,
+                            "nw",
+                            (x, y),
+                            clockwise=True,
+                            start_angle=np.pi,
+                            end_angle=spine_end_angle,
+                        )
+                    )
+
+                    cap_etch_coords.append(partial_info["int_point"])
+
+                    x = north_cpw_etch_left_edge_x
+                    cpw_start_angle = partial_info["cpw_angle"]
+                    assert cpw_start_angle <= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_cpw_etch_radius, "se", (x, y), start_angle=cpw_start_angle, end_angle=0
+                        )
+                    )
+
+                elif sel_partial_valid:  # ne spine curve -> tilted line -> sw cpw curve
+                    raise NotImplementedError
+                    assert self.etch_left_edge_x < south_cpw_etch_right_edge_x, (
+                        f"south_cpw must be connected to capacitor (exceeds {self.etch_left_edge_x} mm). Reduce offset magnitude"
+                    )
+
+                    y_int_val = self.etch_height - p.north_gap_ground
+
+                    spine_circ_center = np.array(
+                        [self.etch_left_edge_x - p.north_west_spine_etch_radius, y_int_val - p.north_west_spine_radius]
+                    )
+                    cpw_circ_center = np.array(
+                        [north_cpw_etch_left_edge_x + p.north_cpw_etch_radius, y_int_val + p.north_cpw_radius]
+                    )
+                    partial_info = self._get_partial_corner_info(
+                        cpw_circ_center,
+                        spine_circ_center,
+                        p.north_cpw_etch_radius,
+                        p.north_west_spine_etch_radius,
+                        y_int_val=y_int_val,
+                    )
+
+                    y = y_int_val
+                    spine_end_angle = partial_info["spine_angle"]
+                    assert spine_end_angle >= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_west_spine_etch_radius, "ne", (x, y), start_angle=0, end_angle=spine_end_angle
+                        )
+                    )
+
+                    cap_etch_coords.append(partial_info["int_point"])
+
+                    x = north_cpw_etch_left_edge_x
+                    cpw_start_angle = partial_info["cpw_angle"]
+                    assert cpw_start_angle <= 0.0, "DEBUG"
+                    cap_etch_coords.extend(
+                        self._get_rounded_corner_coords(
+                            p.north_cpw_etch_radius,
+                            "sw",
+                            (x, y),
+                            start_angle=cpw_start_angle,
+                            end_angle=-np.pi,
+                            clockwise=True,
+                        )
+                    )
+
+                else:
+                    raise RuntimeError("Should not reach this point. Code logic issue")
+
+            x = south_cpw_etch_right_edge_x
+            y = -south_cpw_etch_length
+            cap_etch_coords.append((x, y))
+
+        elif p.north_cpw_length > 0.0 and (p.north_cpw_length < p.north_gap_ground):
+            north_cpw_etch_left_edge_x = self.north_cpw_left_edge_x - p.north_cpw_gap
+
+            if north_cpw_etch_left_edge_x < self.etch_width / 2:
+                raise NotImplementedError
+
+        elif p.north_cpw_length < 1e-6:
+            raise NotImplementedError
+
+        cap_etch = Polygon(cap_etch_coords)
+        return cap_etch

--- a/squadds/core/db.py
+++ b/squadds/core/db.py
@@ -76,6 +76,7 @@ class SQuADDS_DB(metaclass=SingletonMeta):
         view_component_names(component): Print the component names for a given component.
         view_datasets(): Print a table of available datasets.
         get_dataset_info(component, component_name, data_type): Print information about a specific dataset.
+        build_qiskit_metal_component(design, row, name): Build the component declared by a dataset row.
         view_all_contributors(): Print a table of all contributors.
         view_contributors_of_config(config): Print a table of contributors for a specific configuration.
         view_contributors_of(component, component_name, data_type): Print a table of contributors for a specific component, component name, and data type.
@@ -856,6 +857,13 @@ class SQuADDS_DB(metaclass=SingletonMeta):
         except Exception as e:
             print(f"An error occurred while loading the dataset: {e}")
             return
+
+    @staticmethod
+    def build_qiskit_metal_component(design, row, name="component"):
+        """Instantiate the exact Qiskit Metal component declared by a dataset row."""
+        from squadds.components import build_component_from_design
+
+        return build_component_from_design(design, row, name=name)
 
     def create_system_df(self, parallelize=False, num_cpu=None):
         """

--- a/squadds/database/generalized_ncap_dataset.py
+++ b/squadds/database/generalized_ncap_dataset.py
@@ -1,0 +1,143 @@
+"""Normalize generalized interdigital capacitor sweeps for SQuADDS."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+COMPONENT_NAME = "GeneralizedCapNInterdigital"
+CONTRIBUTOR = {
+    "group": "Levenson-Falk Lab",
+    "PI": "Eli Levenson-Falk",
+    "institution": "USC",
+    "uploader": "Saikat Das",
+    "date_created": "2026-07-25",
+}
+MATRIX_KEYS = (
+    "C_G_G",
+    "C_G_N",
+    "C_G_S",
+    "C_N_G",
+    "C_N_N",
+    "C_N_S",
+    "C_S_G",
+    "C_S_N",
+    "C_S_S",
+)
+
+
+def _pairwise_results(matrix: dict[str, float]) -> dict[str, float | str | dict[str, float]]:
+    return {
+        "north_to_north": matrix["C_N_N"],
+        "north_to_south": abs(matrix["C_N_S"]),
+        "north_to_ground": abs(matrix["C_N_G"]),
+        "south_to_south": matrix["C_S_S"],
+        "south_to_ground": abs(matrix["C_S_G"]),
+        "ground_to_ground": matrix["C_G_G"],
+        "top_to_top": matrix["C_N_N"],
+        "top_to_bottom": abs(matrix["C_N_S"]),
+        "top_to_ground": abs(matrix["C_N_G"]),
+        "bottom_to_bottom": matrix["C_S_S"],
+        "bottom_to_ground": abs(matrix["C_S_G"]),
+        "maxwell_matrix": {key: matrix[key] for key in MATRIX_KEYS},
+        "units": "fF",
+    }
+
+
+def validate_source_record(record: dict[str, Any]) -> None:
+    """Validate fields and physical matrix invariants required by the converter."""
+    required = {"cap_instance_name", "cap_options", "ansys_gds", "cap_matrix"}
+    missing = required.difference(record)
+    if missing:
+        raise ValueError(f"Source record is missing required fields: {sorted(missing)}")
+
+    matrix = record["cap_matrix"].get("matrix_elements_fF", {})
+    if set(matrix) != set(MATRIX_KEYS):
+        raise ValueError("Source record must contain the complete 3x3 Maxwell capacitance matrix.")
+
+    for left, right in (("C_G_N", "C_N_G"), ("C_G_S", "C_S_G"), ("C_N_S", "C_S_N")):
+        if abs(matrix[left] - matrix[right]) > 1e-9:
+            raise ValueError(f"Maxwell matrix is not symmetric at {left}/{right}.")
+
+    if any(matrix[key] <= 0 for key in ("C_G_G", "C_N_N", "C_S_S")):
+        raise ValueError("Maxwell matrix diagonal entries must be positive.")
+    if any(matrix[key] > 0 for key in ("C_G_N", "C_G_S", "C_N_S")):
+        raise ValueError("Maxwell matrix off-diagonal entries must be non-positive.")
+
+
+def convert_source_record(record: dict[str, Any], campaign: str, source_file: str) -> dict[str, Any]:
+    """Convert one raw sweep record to the public SQuADDS row contract."""
+    validate_source_record(record)
+    q3d = record["ansys_gds"]["q3d_signal"]
+    matrix = record["cap_matrix"]["matrix_elements_fF"]
+    source_id = f"{campaign}/{record['cap_instance_name']}"
+
+    return {
+        "sim_options": {
+            "sim_type": "cap_matrix",
+            "setup": q3d["setup"],
+            "renderer_options": {
+                "margin_factor_east_west": record["margin_factor_ew"],
+                "margin_factor_north_south": record["margin_factor_ns"],
+                "gds_north_port_length": record["gds_north_port_length"],
+                "gds_north_port_layer": record["gds_north_port_layer"],
+                "gds_south_port_length": record["gds_south_port_length"],
+                "gds_south_port_layer": record["gds_south_port_layer"],
+                "mesh": record["mesh"],
+                "gds_import": q3d,
+            },
+            "layer_stack": record["layer_stack"],
+            "simulator": "Ansys Q3D",
+        },
+        "sim_results": _pairwise_results(matrix),
+        "design": {
+            "design_options": record["cap_options"],
+            "design_tool": "qiskit-metal",
+            "coupler_type": COMPONENT_NAME,
+            "component_name": COMPONENT_NAME,
+            "component_module": "squadds.components",
+            "component_class": COMPONENT_NAME,
+            "pin_names": ["north_end", "south_end"],
+            "pin_aliases": {"top": "north_end", "bottom": "south_end"},
+        },
+        "notes": {
+            "source_id": source_id,
+            "source_campaign": campaign,
+            "source_instance_name": record["cap_instance_name"],
+            "source_file": source_file,
+            "attribution": "Simulated and contributed by Saikat Das, Levenson-Falk Lab, USC.",
+        },
+        "contributor": dict(CONTRIBUTOR),
+    }
+
+
+def iter_source_files(source_root: Path) -> Iterable[Path]:
+    """Yield source JSON files in deterministic campaign/name order."""
+    return sorted(source_root.glob("*/*.json"), key=lambda path: (path.parent.name, path.name))
+
+
+def convert_dataset(source_root: Path, output_path: Path) -> int:
+    """Convert an export tree to a deterministic Hugging Face JSON artifact."""
+    rows = []
+    source_ids = set()
+    for path in iter_source_files(source_root):
+        with path.open(encoding="utf-8") as source:
+            record = json.load(source)
+        relative_path = path.relative_to(source_root).as_posix()
+        row = convert_source_record(record, path.parent.name, relative_path)
+        source_id = row["notes"]["source_id"]
+        if source_id in source_ids:
+            raise ValueError(f"Duplicate source id: {source_id}")
+        source_ids.add(source_id)
+        rows.append(row)
+
+    if not rows:
+        raise ValueError(f"No JSON files found under {source_root}")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as destination:
+        json.dump(rows, destination, indent=2)
+        destination.write("\n")
+    return len(rows)

--- a/squadds/simulations/utils_component_factory.py
+++ b/squadds/simulations/utils_component_factory.py
@@ -1,8 +1,8 @@
 from qiskit_metal import Dict
-from qiskit_metal.qlibrary.couplers.cap_n_interdigital_tee import CapNInterdigitalTee
 from qiskit_metal.qlibrary.couplers.coupled_line_tee import CoupledLineTee
 from qiskit_metal.qlibrary.tlines.meandered import RouteMeander
 
+from squadds.components import create_coupler
 from squadds.components.claw_coupler import TransmonClaw
 from squadds.components.coupled_systems import QubitCavity
 
@@ -19,7 +19,13 @@ def create_claw(opts, cpw_length, design):
 
 def create_ncap_coupler(opts, design):
     opts["orientation"] = "-90"
-    return CapNInterdigitalTee(design, "cplr", options=opts)
+    return create_coupler("NCap", design, "cplr", opts)
+
+
+def create_generalized_ncap_coupler(opts, design):
+    """Create the SQuADDS generalized interdigital capacitor."""
+    opts["orientation"] = "-90"
+    return create_coupler("GeneralizedCapNInterdigital", design, "cplr", opts)
 
 
 def create_clt_coupler(opts, design):

--- a/squadds_mcp/tools/database.py
+++ b/squadds_mcp/tools/database.py
@@ -303,6 +303,10 @@ def register_database_tools(mcp: FastMCP) -> None:
         - Couplers: ``component='coupler'``, ``component_name='NCap'``
           → Contains CapNInterdigitalTee coupler geometry and capacitances.
           Used for half-wave resonator systems.
+        - Generalized couplers: ``component='coupler'``,
+          ``component_name='GeneralizedCapNInterdigital'``
+          → Contains generalized two-terminal interdigital capacitor geometry,
+          signed Maxwell matrices, and north/south pairwise capacitances.
 
         **Note:** Cavity/resonator data uses data_type='eigenmode', not 'cap_matrix'.
         Use ``get_dataset(component='cavity_claw', ..., data_type='eigenmode')`` for that.

--- a/squadds_mcp/tools/generation.py
+++ b/squadds_mcp/tools/generation.py
@@ -30,6 +30,10 @@ SNIPPETS = {
     opts["orientation"] = "-90"
     return CapNInterdigitalTee(design, name, options=opts)
 """,
+    "generalized_ncap": """def create_generalized_ncap_coupler(name: str, design, opts: dict):
+    from squadds.components import GeneralizedCapNInterdigital
+    return GeneralizedCapNInterdigital(design, name, options=opts)
+""",
     "cpw": """def create_cpw(name: str, design, cplr_name: str, qubit_name: str, opts: dict):
     from qiskit_metal.qlibrary.tlines.meandered import RouteMeander
     from qiskit_metal import Dict
@@ -126,6 +130,7 @@ def register_generation_tools(mcp: FastMCP) -> None:
                 - "qubit": TransmonCross
                 - "clt": CoupledLineTee
                 - "ncap": CapNInterdigitalTee
+                - "generalized_ncap": SQuADDS GeneralizedCapNInterdigital
                 - "cpw": RouteMeander
                 - "wirebond": LaunchpadWirebond
                 - "feedline": RouteStraight

--- a/tests/test_component_registry.py
+++ b/tests/test_component_registry.py
@@ -1,0 +1,95 @@
+import pytest
+from qiskit_metal import Dict, designs
+from qiskit_metal.qlibrary.couplers.cap_n_interdigital_tee import CapNInterdigitalTee
+
+from squadds.components import GeneralizedCapNInterdigital, build_component_from_design, get_coupler_spec
+from squadds.components.cavity_claw import CavityClaw
+from squadds.components.coupled_systems import QubitCavity
+from squadds.core.db import SQuADDS_DB
+
+
+def test_generalized_dataset_row_builds_squadds_component():
+    design = designs.DesignPlanar()
+    row = {
+        "design": {
+            "component_module": "squadds.components",
+            "component_class": "GeneralizedCapNInterdigital",
+            "design_options": {"finger_count": "3"},
+        }
+    }
+
+    component = build_component_from_design(design, row)
+
+    assert type(component) is GeneralizedCapNInterdigital
+    assert type(component).__module__ == "squadds.components.generalized_ncap_interdigital"
+    assert sorted(component.pin_names) == ["north_end", "south_end"]
+
+
+def test_flattened_generalized_api_row_builds_squadds_component():
+    design = designs.DesignPlanar()
+    row = {
+        "component_class": "GeneralizedCapNInterdigital",
+        "design_options": {"finger_count": "4"},
+    }
+
+    component = build_component_from_design(design, row)
+
+    assert type(component) is GeneralizedCapNInterdigital
+
+
+def test_database_api_builds_component_declared_by_row():
+    design = designs.DesignPlanar()
+    row = {
+        "component_module": "squadds.components",
+        "component_class": "GeneralizedCapNInterdigital",
+        "design_options": {"finger_count": "2"},
+    }
+
+    component = SQuADDS_DB.build_qiskit_metal_component(design, row, name="from_api")
+
+    assert type(component) is GeneralizedCapNInterdigital
+    assert component.name == "from_api"
+
+
+@pytest.mark.parametrize("wrapper_class", [CavityClaw, QubitCavity])
+def test_modular_wrappers_use_squadds_generalized_component(wrapper_class):
+    design = designs.DesignPlanar()
+    options = Dict(
+        cavity_claw_options=Dict(
+            coupler_type="GeneralizedCapNInterdigital",
+            coupler_options=Dict(finger_count="5", orientation="0"),
+            cpw_opts=Dict(
+                total_length="2000um",
+                left_options=Dict(
+                    trace_width="10um",
+                    trace_gap="6um",
+                    fillet="30um",
+                    meander=Dict(spacing="100um"),
+                ),
+            ),
+        ),
+        qubit_options=Dict(connection_pads=Dict(readout=Dict(claw_cpw_width="10um"))),
+    )
+
+    if wrapper_class is QubitCavity:
+        with pytest.warns(UserWarning, match="convenience wrapper"):
+            wrapper = wrapper_class(design, "system", options=options)
+    else:
+        wrapper = wrapper_class(design, "system", options=options)
+
+    assert type(wrapper.coupler) is GeneralizedCapNInterdigital
+    assert wrapper.pin_names == {"north_end"}
+    assert wrapper.LeftMeander.options.pin_inputs.end_pin.pin == "south_end"
+
+
+def test_legacy_ncap_still_resolves_to_qiskit_metal():
+    spec = get_coupler_spec("NCap")
+
+    assert spec.component_class is CapNInterdigitalTee
+    assert spec.route_pin == "second_end"
+    assert spec.exposed_pins == ("prime_start", "prime_end")
+
+
+def test_unknown_component_is_rejected():
+    with pytest.raises(ValueError, match="Unsupported coupler"):
+        get_coupler_spec("unknown")

--- a/tests/test_generalized_ncap_dataset.py
+++ b/tests/test_generalized_ncap_dataset.py
@@ -1,0 +1,76 @@
+import json
+
+import pytest
+
+from squadds.database.generalized_ncap_dataset import (
+    COMPONENT_NAME,
+    CONTRIBUTOR,
+    convert_dataset,
+    convert_source_record,
+)
+
+
+def source_record():
+    return {
+        "cap_instance_name": "cap_0001",
+        "margin_factor_ew": 20,
+        "margin_factor_ns": 20,
+        "layer_stack": {"metal_thickness_um": 0.25},
+        "cap_options": {"finger_count": "5", "north_cpw_width": "10um"},
+        "gds_north_port_length": "2um",
+        "gds_north_port_layer": "2",
+        "gds_south_port_length": "2um",
+        "gds_south_port_layer": "3",
+        "mesh": {"q3d_signal": {}},
+        "ansys_gds": {"q3d_signal": {"setup": {"AdaptiveFreq": "13GHz"}}},
+        "cap_matrix": {
+            "matrix_elements_fF": {
+                "C_G_G": 50.0,
+                "C_G_N": -12.0,
+                "C_G_S": -14.0,
+                "C_N_G": -12.0,
+                "C_N_N": 22.0,
+                "C_N_S": -9.0,
+                "C_S_G": -14.0,
+                "C_S_N": -9.0,
+                "C_S_S": 24.0,
+            }
+        },
+    }
+
+
+def test_convert_source_record_uses_canonical_names_and_contributor():
+    row = convert_source_record(source_record(), "exp6", "exp6/cap_0001.json")
+
+    assert row["contributor"] == CONTRIBUTOR
+    assert row["design"]["coupler_type"] == COMPONENT_NAME
+    assert row["design"]["component_module"] == "squadds.components"
+    assert row["design"]["pin_aliases"] == {"top": "north_end", "bottom": "south_end"}
+    assert row["notes"]["source_id"] == "exp6/cap_0001"
+    assert row["sim_results"]["north_to_south"] == 9.0
+    assert row["sim_results"]["top_to_bottom"] == 9.0
+    assert row["sim_results"]["maxwell_matrix"]["C_N_S"] == -9.0
+
+
+def test_convert_dataset_orders_rows_and_keeps_campaign_ids_unique(tmp_path):
+    source_root = tmp_path / "export1"
+    for campaign in ("exp7", "exp6"):
+        directory = source_root / campaign
+        directory.mkdir(parents=True)
+        with (directory / "cap_0001.json").open("w") as destination:
+            json.dump(source_record(), destination)
+
+    output = tmp_path / "dataset.json"
+    count = convert_dataset(source_root, output)
+    rows = json.loads(output.read_text())
+
+    assert count == 2
+    assert [row["notes"]["source_id"] for row in rows] == ["exp6/cap_0001", "exp7/cap_0001"]
+
+
+def test_convert_source_record_rejects_asymmetric_matrix():
+    record = source_record()
+    record["cap_matrix"]["matrix_elements_fF"]["C_S_N"] = -8.0
+
+    with pytest.raises(ValueError, match="not symmetric"):
+        convert_source_record(record, "exp6", "exp6/cap_0001.json")

--- a/tests/test_generalized_ncap_interdigital.py
+++ b/tests/test_generalized_ncap_interdigital.py
@@ -1,0 +1,42 @@
+from qiskit_metal import designs
+from shapely.geometry import Polygon
+
+from squadds.components import GeneralizedCapNInterdigital
+
+
+def build_component(options=None):
+    design = designs.DesignPlanar()
+    component = GeneralizedCapNInterdigital(design, "cplr", options=options or {})
+    return design, component
+
+
+def test_generalized_ncap_is_exported_and_builds_default_geometry():
+    design, component = build_component()
+
+    assert component.name == "cplr"
+    assert sorted(component.pin_names) == ["north_end", "south_end"]
+    assert len(design.qgeometry.tables["poly"]) == 3
+
+    for geometry in design.qgeometry.tables["poly"]["geometry"]:
+        assert geometry.is_valid
+        assert isinstance(geometry, Polygon)
+
+
+def test_generalized_ncap_supports_odd_and_even_finger_counts():
+    for finger_count in ("1", "5", "6"):
+        design, component = build_component({"finger_count": finger_count})
+
+        assert component.pin_names
+        assert len(design.qgeometry.tables["poly"]) == 3
+
+
+def test_generalized_ncap_honors_asymmetric_cpw_lengths():
+    design, component = build_component(
+        {
+            "north_cpw_length": "10um",
+            "south_cpw_length": "20um",
+        }
+    )
+
+    assert sorted(component.pin_names) == ["north_end", "south_end"]
+    assert len(design.qgeometry.tables["poly"]) == 3


### PR DESCRIPTION
## Summary
- add and export GeneralizedCapNInterdigital from squadds.components
- resolve dataset rows through the SQuADDS component registry and API builder
- use the SQuADDS component in CavityClaw and QubitCavity modular construction while preserving legacy NCap behavior
- normalize 3,683 generalized interdigital capacitor sweep rows with north/south labels, top/bottom compatibility aliases, signed Maxwell matrices, and Saikat Das contributor metadata
- add MCP generation/database guidance and contributor acknowledgement

## Validation
- 316 tests passed, 4 live Hugging Face tests skipped by their opt-in guard
- all 3,683 normalized rows loaded through datasets and rebuilt successfully in Qiskit Metal
- scoped Ruff checks pass

The corresponding Hugging Face dataset change is available separately in SQuADDS/SQuADDS_DB discussion/22.